### PR TITLE
[setup] 1.2 Chakra UI v3 Provider 연결

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { Providers } from './providers';
 
 export const metadata: Metadata = {
   title: 'WBS',
@@ -8,8 +9,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ko">
-      <body>{children}</body>
+    <html lang="ko" suppressHydrationWarning>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,16 @@
+'use client';
+
+import { Box, Button, Heading, Stack } from '@chakra-ui/react';
+
 export default function HomePage() {
-  return <main>WBS — 초기 스캐폴드</main>;
+  return (
+    <Box as="main" p={8}>
+      <Stack gap={4}>
+        <Heading size="lg">WBS — 초기 스캐폴드</Heading>
+        <Button colorPalette="blue" alignSelf="flex-start">
+          Chakra 동작 확인
+        </Button>
+      </Stack>
+    </Box>
+  );
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
+import type { ReactNode } from 'react';
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "claude-vercel-wbs",
       "version": "0.1.0",
       "dependencies": {
+        "@chakra-ui/react": "^3.35.0",
+        "@emotion/react": "^11.14.0",
         "next": "^14.2.25",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -22,6 +24,244 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@ark-ui/react": {
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@ark-ui/react/-/react-5.36.2.tgz",
+      "integrity": "sha512-2lrZ7+Qtlj7hGx4qU2jZkE892JNrkULg/fUxqUuqmQfv9UGAXhdcw1Hr3N+zBgMDVz3aqip0Qa4v0Mox09MMvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/date": "3.12.0",
+        "@zag-js/accordion": "1.40.0",
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/angle-slider": "1.40.0",
+        "@zag-js/async-list": "1.40.0",
+        "@zag-js/auto-resize": "1.40.0",
+        "@zag-js/avatar": "1.40.0",
+        "@zag-js/carousel": "1.40.0",
+        "@zag-js/cascade-select": "1.40.0",
+        "@zag-js/checkbox": "1.40.0",
+        "@zag-js/clipboard": "1.40.0",
+        "@zag-js/collapsible": "1.40.0",
+        "@zag-js/collection": "1.40.0",
+        "@zag-js/color-picker": "1.40.0",
+        "@zag-js/color-utils": "1.40.0",
+        "@zag-js/combobox": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/date-input": "1.40.0",
+        "@zag-js/date-picker": "1.40.0",
+        "@zag-js/date-utils": "1.40.0",
+        "@zag-js/dialog": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/drawer": "1.40.0",
+        "@zag-js/editable": "1.40.0",
+        "@zag-js/file-upload": "1.40.0",
+        "@zag-js/file-utils": "1.40.0",
+        "@zag-js/floating-panel": "1.40.0",
+        "@zag-js/focus-trap": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/highlight-word": "1.40.0",
+        "@zag-js/hover-card": "1.40.0",
+        "@zag-js/i18n-utils": "1.40.0",
+        "@zag-js/image-cropper": "1.40.0",
+        "@zag-js/json-tree-utils": "1.40.0",
+        "@zag-js/listbox": "1.40.0",
+        "@zag-js/marquee": "1.40.0",
+        "@zag-js/menu": "1.40.0",
+        "@zag-js/navigation-menu": "1.40.0",
+        "@zag-js/number-input": "1.40.0",
+        "@zag-js/pagination": "1.40.0",
+        "@zag-js/password-input": "1.40.0",
+        "@zag-js/pin-input": "1.40.0",
+        "@zag-js/popover": "1.40.0",
+        "@zag-js/presence": "1.40.0",
+        "@zag-js/progress": "1.40.0",
+        "@zag-js/qr-code": "1.40.0",
+        "@zag-js/radio-group": "1.40.0",
+        "@zag-js/rating-group": "1.40.0",
+        "@zag-js/react": "1.40.0",
+        "@zag-js/scroll-area": "1.40.0",
+        "@zag-js/select": "1.40.0",
+        "@zag-js/signature-pad": "1.40.0",
+        "@zag-js/slider": "1.40.0",
+        "@zag-js/splitter": "1.40.0",
+        "@zag-js/steps": "1.40.0",
+        "@zag-js/switch": "1.40.0",
+        "@zag-js/tabs": "1.40.0",
+        "@zag-js/tags-input": "1.40.0",
+        "@zag-js/timer": "1.40.0",
+        "@zag-js/toast": "1.40.0",
+        "@zag-js/toggle": "1.40.0",
+        "@zag-js/toggle-group": "1.40.0",
+        "@zag-js/tooltip": "1.40.0",
+        "@zag-js/tour": "1.40.0",
+        "@zag-js/tree-view": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@chakra-ui/react": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.35.0.tgz",
+      "integrity": "sha512-qzfRNLwxKjxx2IXjBj6uz1nYI+pKsq6uwHxO619+hx1OzNNuwLIjEHJxnDfBzoynO7sPCBlubMwFWb1e1PrXzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ark-ui/react": "5.36.2",
+        "@emotion/is-prop-valid": "^1.4.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@pandacss/is-valid-prop": "^1.4.2",
+        "csstype": "^3.2.3"
+      },
+      "peerDependencies": {
+        "@emotion/react": ">=11",
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -57,6 +297,130 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -121,6 +485,31 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -158,6 +547,25 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -204,6 +612,41 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -427,6 +870,12 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@pandacss/is-valid-prop": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.10.0.tgz",
+      "integrity": "sha512-OmEHkDj3BRkHYLxHwNFYJkcwF84c7PuHsWHmmmNLJnmk8z0RVlDQei4GxWjfW1bnvCihCwakJ8Xq6GDRlmcDiQ==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -495,6 +944,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -1084,6 +1539,948 @@
         "win32"
       ]
     },
+    "node_modules/@zag-js/accordion": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.40.0.tgz",
+      "integrity": "sha512-YDdyvZJ6fr92RZazyXQq+juT3ZA0ubjDISptb5YPgMoTPdnjKNiICPpMeCeVj1ncYRDkHXrOdChS/5CtuX/K6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/anatomy": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.40.0.tgz",
+      "integrity": "sha512-oiB4uAaV//L38JluLVPtOHO3xvqambrfrXVOoq4kmNrBv1LLlCmFvrXA2HOR9lakn4ExK27XSUrKhUN7YlKjfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/angle-slider": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/angle-slider/-/angle-slider-1.40.0.tgz",
+      "integrity": "sha512-6X6bOBoCyYG0/lFY0Y+AXJZZG6CeYQiWkcMXvegxCC2zxthodqOVzkVOASW+6rzLjn2bru+V5O9RMjNgmCumKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/rect-utils": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/aria-hidden": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.40.0.tgz",
+      "integrity": "sha512-lNWujEIlfGKwMQIcgfXuOZSsJD2avrgPsQHrXNVF9mkXygjLFcIRKz2pEexTSCqFh/HuUZJ6rG4pM/hJ/BiVCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/async-list": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/async-list/-/async-list-1.40.0.tgz",
+      "integrity": "sha512-hLGUTtwRFl6FIdYxSIYSeLQjJeG4isKpdmGCUvtWNnKr7ayf1yAkkSwX10SdBMWOCldbtvKCZXumKvP6dDwNvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/core": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/auto-resize": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.40.0.tgz",
+      "integrity": "sha512-eZC+AGKUip7UMu41/ApeT1wCIgn2fmo63FJeGAdMMD8E9M8M7QLsfISMIoieNNGBAYWhSyqELQ3jPgkUf6xReA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/avatar": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/avatar/-/avatar-1.40.0.tgz",
+      "integrity": "sha512-DayZDsNXbipT+1GUkX29tVhO4hZonDnidwE3SjEQv9Ic9vCdnwP95+B0FPEuaca03F5ZXFqVXjnPmRVbRMyDYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/carousel": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/carousel/-/carousel-1.40.0.tgz",
+      "integrity": "sha512-9svWc2jjvUP8iQ0afuu/ZAI75PuPLm4qB7h+10rmDrAgUPn7fwUBVzyATKubJPdtmaYQQvTTIiZU2B8mV88oGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/scroll-snap": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/cascade-select": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/cascade-select/-/cascade-select-1.40.0.tgz",
+      "integrity": "sha512-0fkE0Fd2VQ4QsaWXHdgQxHWiaef3UWW0l6Jd47frtMNnrvg5t5Xfqowa7c2S23hcduOUfz2WC0xEuGXnO4UVDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/collection": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/rect-utils": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/checkbox": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/checkbox/-/checkbox-1.40.0.tgz",
+      "integrity": "sha512-oFCgnkOjrUDejB1wEp5s3cyJ+uFe/GoI3+wqNyckqOtcdKL1MBxy193GYVdj0LDfuCNrk8V0aIJGTdusCD2b4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/clipboard": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/clipboard/-/clipboard-1.40.0.tgz",
+      "integrity": "sha512-QbFhJMwwUxTKcbWyb9ZrKgAp13U4+IzfHSLhPxbDVSQ15mIrjIkjW68gS6ElzhRDwGr1qawkZVApsqcToUqSaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/collapsible": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.40.0.tgz",
+      "integrity": "sha512-xDLY4j9D3gdoTirkwzMaCtelfCjnMhBzPyY6c/mh4oPvD3RB6dr3V3kI80i3yxHaUUeDCIUm/XAxK0InPsRBug==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/collection": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.40.0.tgz",
+      "integrity": "sha512-+3o1nvbcA9Kz2hDDFf8Kngpd+of33S4TS5Tb9KvrHlU5ieQdvEUtc7/pWG2aCTkGpmgda+j91akB6ZB8+oVkvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/color-picker": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/color-picker/-/color-picker-1.40.0.tgz",
+      "integrity": "sha512-lT93xd1BlNBbitl2RxST8ARYE6q/HZD5a0QhMIT1RbndB8F4e9j/NxkStgE9f0QqgpC/rO+nKHLoR+H1xs/EkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/color-utils": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/color-utils": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/color-utils/-/color-utils-1.40.0.tgz",
+      "integrity": "sha512-PZihcGheb5bn0/cEUwozjJjPoKkEwlJNpTA5mUxj/+sOElLaZM+zY2AnGYeMl6w5zIyZZUDoJMIT5rcb5sN87g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/combobox": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/combobox/-/combobox-1.40.0.tgz",
+      "integrity": "sha512-5IVCDrB8m7XrKBu28j7bIRE5KiyKJLPDZB3AJ+PLJyL69D+9z1anhLDmkUYcPseyCasszLKzIejby+kYQJgHlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/collection": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/live-region": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/core": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.40.0.tgz",
+      "integrity": "sha512-0YcqCh7TmhSonkbKM/7NWolxlaQgvvXgqedocW9oeRYiDJIpBZyRqnHPoGAS2XwbBPkCnrqSosxSF5yBjhZpgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/date-input": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-input/-/date-input-1.40.0.tgz",
+      "integrity": "sha512-/VU8g3dugggC5xW2OJW1KONWzPkEbK/yLA0lPxymW/Uo0ixh2mKJUVTOTqDFWf1b0vzLX2XlYoLL+I2ryUyPvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/date-utils": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/live-region": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      },
+      "peerDependencies": {
+        "@internationalized/date": ">=3.0.0"
+      }
+    },
+    "node_modules/@zag-js/date-picker": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-picker/-/date-picker-1.40.0.tgz",
+      "integrity": "sha512-Nm3aSKn/5tGOZk8rIddLyBk+oeE0zr/ZsJuuTc3rysd04owVy1UhmUh6X9CqfTJtwTDpUZe+orHaIvKlE3Rd0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/date-utils": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/live-region": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      },
+      "peerDependencies": {
+        "@internationalized/date": ">=3.0.0"
+      }
+    },
+    "node_modules/@zag-js/date-utils": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-1.40.0.tgz",
+      "integrity": "sha512-nuB1QM3X7yY0k2JiZbHHm6wigY+Cl1QK6sRlh+C7mOyzEKnNEqNSVIqgSionCtWO6zAZh1R8Znp5ZeCdbbc27w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@internationalized/date": ">=3.0.0"
+      }
+    },
+    "node_modules/@zag-js/dialog": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.40.0.tgz",
+      "integrity": "sha512-1FHxR7/Kuu+9K2dxH7dKlSckCZ26n5ec79qWr0aMSSs2DF+ypQf5GUlaS6z2UqroZvIoJCvABVMm9OMko/qxlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/aria-hidden": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-trap": "1.40.0",
+        "@zag-js/remove-scroll": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/dismissable": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.40.0.tgz",
+      "integrity": "sha512-bBkFvPg/zbYn31ZgEfx8not6s2Ekx7zU2sO8tGXb8rYPnHBfGDYEzVQansUStJn0Atzw+y7XR7B3G3u5AFQJKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/interact-outside": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/dom-query": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
+      "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/types": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/drawer": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/drawer/-/drawer-1.40.0.tgz",
+      "integrity": "sha512-N2OR5ZYuTsWkYYmwsNgmL+wfuM3qUxB8GAfo53AWvOh07QUVz1Dvh1WP4km5L6Tkz4UBQZACu8T/ZLyeZ+PdWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/aria-hidden": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-trap": "1.40.0",
+        "@zag-js/remove-scroll": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/editable": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/editable/-/editable-1.40.0.tgz",
+      "integrity": "sha512-X23wOg42BPvFWfJQi3yd8HiL8xtisrpL5ouFEzba56SQIxWZHDRpeWoqXqyLODq2/z2+SsZ0wV3laRD3ZH0C2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/interact-outside": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/file-upload": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/file-upload/-/file-upload-1.40.0.tgz",
+      "integrity": "sha512-hUZlJYjSGk7SAflTmQIjZv6M+icujaHS6I+dik2LM48rLWwNa/GYTNx+uY4zJLd9oW1eEj+6NcCYZpPWzKku4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/file-utils": "1.40.0",
+        "@zag-js/i18n-utils": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/file-utils": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/file-utils/-/file-utils-1.40.0.tgz",
+      "integrity": "sha512-BGny4rafiBQ5TPCBXfzbH7lSyFdnoix7brq/+FllKpDqpWPQz0tIsgSZueF/Z8GPTrAkwMKOFI99P7OVhAhRig==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/i18n-utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/floating-panel": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/floating-panel/-/floating-panel-1.40.0.tgz",
+      "integrity": "sha512-e2QXwapCbjLJnU+MAz06CoByj4XJ3sdSBgWF+PSe2X2T8dd/FkZUnaDPaX0yyfyTWKzBbyRRNyon2LMAs8ndHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/rect-utils": "1.40.0",
+        "@zag-js/store": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/focus-trap": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.40.0.tgz",
+      "integrity": "sha512-Q6W+DU7pix5rtRwoDnYzTYMkUV2kMWrFV0/EdNN3spFSvnUSkDWRmcNpzf+56AuCNeqsAZxaLJpsHLZkcT2xrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/focus-visible": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
+      "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/highlight-word": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/highlight-word/-/highlight-word-1.40.0.tgz",
+      "integrity": "sha512-+aeVn3S5NPG6Tk4Sanl0VZk/0atjnF7Xy7POPs1HD5SBui29/6i3vn3bUBNXJXrnhUoNrUhuySVYVhgkffcQ7w==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/hover-card": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/hover-card/-/hover-card-1.40.0.tgz",
+      "integrity": "sha512-lkuLaikPLBIOnR0X75kSXdDYgv3ritAsn4TF1eGs12iYnZVX4PTL3J39tVNm9QrEXZ+iKcA1D2cUXNhEteCTyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/i18n-utils": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/i18n-utils/-/i18n-utils-1.40.0.tgz",
+      "integrity": "sha512-8D3ki9V81gMKZvtRfNVoHCBDVYjr+WJLBvdfSv3cdOsVM2/E8//xAfYbYzl5Fdmeny3H71fxBNqOX05GN4K6OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/image-cropper": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/image-cropper/-/image-cropper-1.40.0.tgz",
+      "integrity": "sha512-bpTCaiUXM0Mh6ddoJ1fA1B/YXp5Fc8LA0hg8CuEByDwGRVKPJ0KotL6QXMF6cEJZ1fcHF3Lcmpbj5Xotfkr4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/interact-outside": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.40.0.tgz",
+      "integrity": "sha512-Fws+O4uD9vS0I5KVcf3U2tNjLKvqlv+RExFbTywckDLOCJ145M/pMQWTr1FHil04jk5PFyM1iGfsbom8tozHpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/json-tree-utils": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/json-tree-utils/-/json-tree-utils-1.40.0.tgz",
+      "integrity": "sha512-7zEzU59Gz76nV7n3l70uMB5yAOOQMmt1PTAni6S97uw7/6KzPktsEWBcw7ocC4IIA42PKdT7akpq721H0vthbA==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/listbox": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/listbox/-/listbox-1.40.0.tgz",
+      "integrity": "sha512-zB33y+dk6/e0ZTs3wun2KsuPaH/wygOuD8scnH2a2Y/W9a2P1rq503Kgm5d5kVXBKQLxOBwievWJ8Blajv8LnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/collection": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/live-region": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/live-region/-/live-region-1.40.0.tgz",
+      "integrity": "sha512-i1Dx02KGcQOAZGNhkFe8kz26gYJcn7KsT/M1UovjS9RTbl9diY8ShiyfIAhqruoaHQyqsHMRh/f7Idu45HdiDA==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/marquee": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/marquee/-/marquee-1.40.0.tgz",
+      "integrity": "sha512-XfvAwSNYXV3fEIRc44a9sAsoJoLKt+CWbpSPgQBpiFPpWh0rZ8frUZCslevTzBB3ifIWoSg+svDHQOGsDa8wGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/menu": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-1.40.0.tgz",
+      "integrity": "sha512-FRBqwsOjxBi0eSwqwrOw2td1rd0Xxl0f41J2lGc8E7z+2PabbBcJ/poqSiEn8YoaCT4mAWNjt4QQU/Pe1bRJ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/rect-utils": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/navigation-menu": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/navigation-menu/-/navigation-menu-1.40.0.tgz",
+      "integrity": "sha512-aJkEGYH8P9NfsQOjxMzxuF4YrrV2N1GQj6Y5Ow19MKuLh42o35bUhwoGsYjFbxgEcImabINtZJqtAPAkOdJXmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/number-input": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/number-input/-/number-input-1.40.0.tgz",
+      "integrity": "sha512-WffdeqSOpsKmgPzBkNZl9nAolQPlyl9dIabaPguGgXdYtZW/OGCGj8jCYqyEu4VL3kDPPVVQRWEqC/XzwzVCRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/number": "3.6.5",
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/pagination": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.40.0.tgz",
+      "integrity": "sha512-Ykotky0A/7rswb6BfOD9aXL1EssKwUYfBRbdWGe52uhVc7dGagMSTUDRVeNhVsP/MEdtwqys7urvDbAlEqq+GA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/password-input": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/password-input/-/password-input-1.40.0.tgz",
+      "integrity": "sha512-mD4tbA4m82oV+0NbJ+P00Q4Gwz+zf1kZEZ3Z48ohICfK/WO1KhCgviY7vu/7bCMnRiD3dbi+nEeym8Kb29wRHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/pin-input": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/pin-input/-/pin-input-1.40.0.tgz",
+      "integrity": "sha512-iJIXDJC+9DUx+A3sRdTmHV7vPZXCw9O6le3R0lKf/8kQOgj7FKjbVw2SkUMAoOZ0u5J7Zwg2oZc7ddt1pwUk9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/popover": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.40.0.tgz",
+      "integrity": "sha512-bjvOep1YNlsvIYGh/rPsFCHjH2cCt2aKsVLyRvzTT1jhGZJvBdQKQBJjSuG5Nh4y1PUqtrrz69ZMWRrJGQ3rNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/aria-hidden": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-trap": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/remove-scroll": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/popper": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.40.0.tgz",
+      "integrity": "sha512-rCkgqgwlpgMwcnuSVrZK2xXl1Mvptpuw3cZy6rC2C5F3yE1GmWohdts5VkeQNro+sd/xHTdVovOqY6cU9Htj1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/presence": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/presence/-/presence-1.40.0.tgz",
+      "integrity": "sha512-P0bAuzEIDuMglE1xfmW5xTuSBlWjNZ8nOGXoIksKOKb+b+jy2Vys6WjZjKipV/jop4u85wfzKchcPc3C+cXuog==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/progress": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/progress/-/progress-1.40.0.tgz",
+      "integrity": "sha512-V61a5CHEs8suevQVS+/1ENj1RDVYNOUUTawK6uriCA6Ol59xe30DmF+eV6Y9miM7L/pN3YjZRq9uEDJMXXK32g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/qr-code": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/qr-code/-/qr-code-1.40.0.tgz",
+      "integrity": "sha512-xD37tVrQ46CeqVLqkSm61kURoJ4Z/uOFcB8z7Hu3UX+1OFTfkhgrns6iLUneoRjO3hsqQaTaVkxVOQeLYWb+wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0",
+        "proxy-memoize": "3.0.1",
+        "uqr": "0.1.2"
+      }
+    },
+    "node_modules/@zag-js/radio-group": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.40.0.tgz",
+      "integrity": "sha512-sFJCdyOKzQC9hylSP19R71yv44by/C78D9EHfsxQJtvOgDv9E+h13NNX4n9wWyubC20xftlxkja8sNT5NfJKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/rating-group": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/rating-group/-/rating-group-1.40.0.tgz",
+      "integrity": "sha512-UMBI3xAMcm7otpAczMGPEA7jC1hvV8NhnZ4mN3oftJB0bc1winoXxJdCkrXN58TTNWrGNSRzjtm048G+HPCdpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/react": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-1.40.0.tgz",
+      "integrity": "sha512-2TFS1HYABYGc0lurC+4WEXvKkpxsVv6vKm+t8QAL7wfoeZnw6HDQWLc91kINp89vln+A2kwCfYqIq8HSm+9EeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/core": "1.40.0",
+        "@zag-js/store": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@zag-js/rect-utils": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.40.0.tgz",
+      "integrity": "sha512-ikgLuE4rLlACm4mGLp6Ga8sJA44uFwohA1nVmb95sQ+VIyx2naf91CEF7SMrZVEwFKHaHpxdKVQSZLRjJqO/dw==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/remove-scroll": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.40.0.tgz",
+      "integrity": "sha512-f6EgODnJMRtkbgdJCgyllND8jui+RtPrCZy6JYhhOg7KQ+bFfV36KzWQMty38ZdOyrh23UUO7MJ3WGcFXPvk3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/scroll-area": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/scroll-area/-/scroll-area-1.40.0.tgz",
+      "integrity": "sha512-7EtWETRIn8dY7xqAeMOlnEuzhOrtc65mN/0YvT3XYcBz/CzmHzyZTmos3UXBJGnKHSGj61aEpP9g3RK+x/w63A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/scroll-snap": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/scroll-snap/-/scroll-snap-1.40.0.tgz",
+      "integrity": "sha512-XtjeOd+pwGX0+K7NvsQncrKwV8CTSzHfVVJrdQ+MweiWBpGNeAh43ySN4L+KSTgtnUiZbuwBIxlKK0tX+WupgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/select": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/select/-/select-1.40.0.tgz",
+      "integrity": "sha512-auMI9SvocVvKHNWF2DobyQN6+1k3OO6UsQTdkofvbHxX7maosy8ZXA6k1r9Ndt4qLUu7CbdAAQ+qJ4VkgJyvxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/collection": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/signature-pad": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/signature-pad/-/signature-pad-1.40.0.tgz",
+      "integrity": "sha512-L0LTxcpdckaGdDDXcQCr4AG+J9xUHH+lsenH7NG4ZI7rSr4nRmHMdDH0GR7nBa6MMdPIIimjWIE/TwZ1OuHzCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0",
+        "perfect-freehand": "^1.2.3"
+      }
+    },
+    "node_modules/@zag-js/slider": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.40.0.tgz",
+      "integrity": "sha512-xZGycm+ghGFG3kTYq8g0t1Av1moxg45WiFz5E3bRgP7YU9beSTaFZI8h6f65NiC5P3YuwA0RoYxA46GH22qoZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/splitter": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/splitter/-/splitter-1.40.0.tgz",
+      "integrity": "sha512-64KNKwlIjyUIjp7i/whDCpREiSFrNI/cF7MpBJvBGRPUWq8NpNxMGKWD+vBCV+JC61QF9xg/NgNoigFycS9sYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/steps": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/steps/-/steps-1.40.0.tgz",
+      "integrity": "sha512-5sVFzcIYubCn1nJSQIx9WWNlJuFoOJMpkD/ZMwNp0LzpnmnspsCOmdnQUWEftMQ1KdwZ+qNgfo/+kHclb9cBjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/store": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.40.0.tgz",
+      "integrity": "sha512-EmgYIdbNZ4TN4Qht/jugY4UVkaWx69l8P1qiX23U4YwqNLq10tyOJmcXWbvsrprU1dGb24B+xq0WBm/RIjw4WA==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "3.0.1"
+      }
+    },
+    "node_modules/@zag-js/switch": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.40.0.tgz",
+      "integrity": "sha512-hUH3AF79ndSFZxt7Plw7mVZV0QlM0kFqKwrAGBEOE77P3rKpOsMJ3wWgMb3w6nwlxGQsbwmMgAFvYUslLpM4Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/tabs": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.40.0.tgz",
+      "integrity": "sha512-xqfPC2nQ6Bn4nqy1L+1CVcQcg/Z7K2q753OvsX2C8Wtu+7tF//HyMbOpF6fGikqlLkUzCkvjkqDjdOXcfWN9ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/tags-input": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.40.0.tgz",
+      "integrity": "sha512-3cB7nPlUvzZNZwQw5AaTuxwcRn1n2qkDCjLEb2NEwtmI+YxHbK3k1MtXjTccjcYjU8cAkv+jaeyZPs6KFKQcHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/auto-resize": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/interact-outside": "1.40.0",
+        "@zag-js/live-region": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/timer": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/timer/-/timer-1.40.0.tgz",
+      "integrity": "sha512-Rvet226fhUtZnItjHpUYV7MH0uEFZfXT9PSRrX5jdiU4/P0eWKbirwi//AVeqcWFexXvw6ajYSfQN7EVyr2x4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/toast": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/toast/-/toast-1.40.0.tgz",
+      "integrity": "sha512-EDH43zdiH4Bz30cE6YI9g//qXGOOfWObM3dFLG8I0q/cJRf7/6jO82rwZAHPwfOSfKhUDxStirD8F6eoY6BWXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/toggle": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle/-/toggle-1.40.0.tgz",
+      "integrity": "sha512-DW7682lzTP2eDlMvrS7tUX3zAm7ufrrKr7VDiX8BB6oXBRETXrVIxCYNuoIdqjwXebdjAoxaCiUZEreRVucYQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/toggle-group": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.40.0.tgz",
+      "integrity": "sha512-+JKcnfEbdQnr5p7uRvYLdivhUsM6iio71UC10tK74nXYRnYm0/Uvxg3oQzvbNTq9WdcU/DIh3gZVZ2Vex9nBnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/tooltip": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.40.0.tgz",
+      "integrity": "sha512-pyrvit+nB8dIwVNTGBRlHPsh7yMJGAxxM1zfY7HOTJqF+n6+6xYTQ4gQ/Ocy1Q7I5kO88+m16naEh0qLFiTZww==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/tour": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tour/-/tour-1.40.0.tgz",
+      "integrity": "sha512-VczYGFQM9xsSbfy5N0NP91GdKxbYvfPCDAguD+WQSs1umEIgAAozSKPUdV3NNCX5Pq6B1F3dBxi6gYPdNqrAHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-trap": "1.40.0",
+        "@zag-js/interact-outside": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/tree-view": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tree-view/-/tree-view-1.40.0.tgz",
+      "integrity": "sha512-v/20ekjbM+HXDEkpHAz6k8WpoZRmZmdCApDIkIgXVHPRQk+kwAiiIPY20ZDG+DjRu7Lh0MUdQavdZtGj6Ihwkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/collection": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/types": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.40.0.tgz",
+      "integrity": "sha512-LVvxEyqFv/u9SEe5xdivvG2vYb9cCmbkD+5r6s+IGljpDLaRgv4BYyxEh40ri1ai070tL08ZKmoLfx2/xfvY/A==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.2.3"
+      }
+    },
+    "node_modules/@zag-js/utils": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.40.0.tgz",
+      "integrity": "sha512-XUpqDtXfHe7CySjOhLPLj9H8rxbiFUJAGgmBzNdpsGPP4wx12cpOXrpSjRXZ2kMwooMPz/P7RPDBteto8sqhAQ==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1381,6 +2778,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1464,7 +2897,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1540,6 +2972,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1559,7 +3013,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -1627,7 +3080,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1726,6 +3178,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -1809,7 +3270,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1907,7 +3367,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2093,6 +3552,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2409,6 +3869,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2492,7 +3958,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2816,13 +4281,21 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/ignore": {
@@ -2839,7 +4312,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -2913,6 +4385,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -2994,7 +4472,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -3378,11 +4855,29 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -3471,6 +4966,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3561,7 +5062,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3889,13 +5389,30 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -3932,7 +5449,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -3951,6 +5467,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/perfect-freehand": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.3.tgz",
+      "integrity": "sha512-bHZSfqDHGNlPpgH2yxXgPHlQSPpEbo+qg7li0M78J9vNAi2yjwLeA4x79BEQhX44lEWpCLSFCeRZwpw0niiXPA==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4032,6 +5563,21 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-memoize": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.1.tgz",
+      "integrity": "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4094,7 +5640,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
@@ -4169,7 +5714,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4497,6 +6041,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4791,6 +6344,12 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4808,7 +6367,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5053,6 +6611,12 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/uqr": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
+      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5285,6 +6849,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@chakra-ui/react": "^3.35.0",
+    "@emotion/react": "^11.14.0",
     "next": "^14.2.25",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
## 요약
Epic 1.0 두 번째 서브이슈. Next.js App Router 위에 Chakra UI v3 Provider를 연결해 앞으로 만드는 모든 UI 컴포넌트가 Chakra 토큰/시스템을 공유하도록 한다.

## 변경
- `app/providers.tsx` (신규) — `'use client'` + `ChakraProvider value={defaultSystem}`
- `app/layout.tsx` — `Providers` 로 children 감쌈, `<html suppressHydrationWarning>` 추가
- `app/page.tsx` — 동작 확인용으로 Chakra `Box / Heading / Button / Stack` 로 최소 UI 렌더
- `package.json` — `@chakra-ui/react ^3`, `@emotion/react` 추가

## DoD
- [x] `npm install` (Chakra v3 + emotion) ✅
- [x] `npm run build` ✅ (Next.js 14.2.35, `/` 페이지 정적 생성)
- [x] `npm run lint` ✅ (No issues found)
- [x] 홈 페이지에 Chakra Button 배치 → 빌드 시 프리렌더 확인 (상호작용 수동 검증은 `/dev-server` 또는 Playwright MCP)
- [x] 수동 작성 파일 수 ≤ 10, 수동 작성 라인 ≤ 300 (lockfile 제외)
- [x] 대응 J 시나리오 없음 (부트스트랩)

## 참고
- 부모 에픽: #1
- 이슈: #11
- Chakra v3 공식 Next.js App Router 가이드의 `ChakraProvider value={defaultSystem}` 패턴을 그대로 적용 (v2 와 API 다름).