### PR TITLE
[db] 1.5 tasks 스키마 정의 + 첫 drizzle 마이그레이션

### DIFF
--- a/drizzle/0000_yielding_warhawk.sql
+++ b/drizzle/0000_yielding_warhawk.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "tasks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"parent_id" uuid,
+	"title" text NOT NULL,
+	"description" text,
+	"assignee" text,
+	"status" text DEFAULT 'todo' NOT NULL,
+	"progress" integer DEFAULT 0 NOT NULL,
+	"start_date" date,
+	"due_date" date,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tasks_status_check" CHECK ("tasks"."status" in ('todo','doing','done')),
+	CONSTRAINT "tasks_progress_check" CHECK ("tasks"."progress" between 0 and 100)
+);
+--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_parent_id_tasks_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."tasks"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,126 @@
+{
+  "id": "40e3f929-3bb8-4be2-90cd-994349bb6309",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee": {
+          "name": "assignee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_parent_id_tasks_id_fk": {
+          "name": "tasks_parent_id_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_status_check": {
+          "name": "tasks_status_check",
+          "value": "\"tasks\".\"status\" in ('todo','doing','done')"
+        },
+        "tasks_progress_check": {
+          "name": "tasks_progress_check",
+          "value": "\"tasks\".\"progress\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1776996009274,
+      "tag": "0000_yielding_warhawk",
+      "breakpoints": true
+    }
+  ]
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,4 +1,23 @@
-// Drizzle 스키마의 단일 진실 원천(source of truth).
-// 실제 tasks 테이블 정의는 1.5 에서 이 파일에 추가된다 (CLAUDE.md §3).
-// 여기서는 drizzle-kit generate 가 파일을 찾을 수 있도록 빈 export 만 유지한다.
-export {};
+import { pgTable, uuid, text, integer, date, timestamp, check } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+
+export const tasks = pgTable(
+  'tasks',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    parentId: uuid('parent_id').references((): any => tasks.id, { onDelete: 'cascade' }),
+    title: text('title').notNull(),
+    description: text('description'),
+    assignee: text('assignee'),
+    status: text('status').notNull().default('todo'),
+    progress: integer('progress').notNull().default(0),
+    startDate: date('start_date'),
+    dueDate: date('due_date'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    statusCheck: check('tasks_status_check', sql`${t.status} in ('todo','doing','done')`),
+    progressCheck: check('tasks_progress_check', sql`${t.progress} between 0 and 100`),
+  }),
+);


### PR DESCRIPTION
## 요약
Epic 1.0 의 **마지막** 서브이슈. `tasks` 테이블을 Drizzle 스키마로 정의하고 그에 대응하는 첫 마이그레이션 파일을 생성·커밋한다. 이 PR 이 머지되면 Epic 1.0 이 닫히고, 이후 데이터 레이어(Epic 3.0) / 목록 뷰(4.0) / CRUD(5.0) 가 이 스키마 위에 올라간다.

## 변경
- `lib/db/schema.ts` — CLAUDE.md §3 의 권위 있는 정의를 **문자 그대로** 옮김
  - `id` uuid PK (`gen_random_uuid()`)
  - `parent_id` uuid self-ref FK, `ON DELETE CASCADE`
  - `title` text NOT NULL, `description`/`assignee` text
  - `status` text NOT NULL DEFAULT `'todo'` + CHECK `in ('todo','doing','done')`
  - `progress` integer NOT NULL DEFAULT `0` + CHECK `between 0 and 100`
  - `start_date`/`due_date` date (nullable)
  - `created_at`/`updated_at` timestamptz NOT NULL DEFAULT `now()`
- `drizzle/0000_yielding_warhawk.sql` — `drizzle-kit generate` 산출물. 수동 편집 없음.
- `drizzle/meta/0000_snapshot.json`, `drizzle/meta/_journal.json` — Drizzle 마이그레이션 메타.

## 로컬 검증
1. `supabase start` → Postgres 컨테이너(127.0.0.1:54322) 기동
2. `npm run db:generate` → `drizzle/0000_*.sql` + `meta/*` 생성 (SQL 수동 리뷰)
3. `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres npm run db:migrate`
   → `migrations applied successfully!`
4. `docker exec supabase_db_claude-vercel-wbs psql -U postgres -d postgres -c "\\d tasks"`
   → 11 컬럼 + PK + self-ref FK(cascade) + `tasks_status_check` + `tasks_progress_check` 모두 존재

## DoD
- [x] `tasks` 테이블이 로컬 DB 에 존재 (`\\d tasks` 로 확인)
- [x] `drizzle/` 가 git 에 커밋됨 (SQL + meta)
- [x] SQL 수동 편집 0 — 전부 `drizzle-kit generate` 산출물
- [x] `npm run build` ✅ / `npm run lint` ✅
- [x] 수동 작성 파일 ≤ 10, 라인 ≤ 300 (자동 생성 SQL/메타 제외)
- [x] 대응 J 시나리오 없음 (부트스트랩의 마지막 단계)

## 참고
- Closes #14
- 부모 에픽: #1 — **이 PR 머지로 Epic 1.0 닫힘 예정**
- 다음 단계: Epic 2.0 CI(`.github/workflows/db-migrate.yml`) + Epic 3.0 데이터 레이어(queries / Server Actions) 가 병렬로 착수 가능 (플랜 §3-2 의존성 그래프).