### PR TITLE
docs: #16 README 배포 섹션 path filter 안내 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Supabase Cloud 프로젝트 생성
 
 이 저장소에는 이미 `.github/workflows/db-migrate.yml` 이 들어 있습니다. `main` 브랜치에 push되면 Drizzle 마이그레이션이 자동으로 원격 Supabase DB에 적용됩니다.
 
+> ℹ️ 이 워크플로우는 `drizzle/**`, `lib/db/schema.ts`, `drizzle.config.ts`, `package.json`, `package-lock.json`, `.github/workflows/db-migrate.yml` 가 변경된 push에만 실행됩니다. README나 앱 코드만 고쳐서 main에 올려도 마이그레이션 잡은 돌지 않는 것이 정상입니다. 수동으로 돌리고 싶다면 Actions 탭에서 `DB Migrate (Production)` → **Run workflow** 버튼을 쓰면 됩니다.
+
 **사전 준비 (GitHub 저장소 UI에서)**:
 
 1. GitHub 저장소 페이지 → **Settings → Environments → New environment** → 이름 `production`.


### PR DESCRIPTION
## Summary

이슈 #16 — README 배포 섹션과 `.github/workflows/db-migrate.yml`의 정합성을 점검하고 누락 안내를 보강했습니다.

### 정합성 점검 결과

이미 일치하는 항목:
- `PRODUCTION_DATABASE_URL` (secret) — Session/Direct pooler, **port 5432** 명시 (README §1 line 286, §트러블슈팅 line 353)
- Vercel 런타임의 `DATABASE_URL` — Transaction pooler, port 6543 명시 (README line 287, 322)
- `production` environment 생성 방법 — Settings → Environments → New environment (line 296)
- Required reviewers 팁 — line 299
- CLAUDE.md §5·§7·§10과 문구 충돌 없음

### 보강한 내용 (+2 lines)

README 292 라인에서 "`main` 브랜치 push → 자동 migrate"로만 안내하고 있었으나, 실제 워크플로우에는 path filter가 걸려 있어 `drizzle/**`·`lib/db/schema.ts`·`drizzle.config.ts`·`package.json`·`package-lock.json`·워크플로우 자신 이외의 변경에는 잡이 돌지 않습니다. 수강생이 다른 파일만 고치고 main에 올린 뒤 "왜 Actions가 안 돌지?"로 막히지 않도록 path filter 조건과 수동 실행(Actions 탭 → Run workflow) 방법을 한 줄 노트로 추가했습니다.

## 범위

- 파일: `README.md` 1개, +2 라인 (DoD "수정 ≤ 10, 라인 ≤ 300" 충족)
- 워크플로우 YAML은 이 PR에서 건드리지 않음 (이슈 #15 PR #28의 몫)

## Test plan

- [x] README와 워크플로우 YAML의 환경변수 이름 일치: `PRODUCTION_DATABASE_URL`, `DATABASE_URL`, `NEXT_PUBLIC_*`
- [x] README와 워크플로우 YAML의 environment 이름 일치: `production`
- [x] 포트 분리 명시: 5432(migration) vs 6543(runtime)
- [x] 추가한 노트의 path 목록이 실제 워크플로우 `on.push.paths`와 일치
- [x] 추가한 노트의 워크플로우 표시 이름 `DB Migrate (Production)`이 YAML `name:`과 일치

Closes #16
Closes #2

> 부모 에픽 #2도 함께 닫도록 `Closes #2`를 포함. 쌍둥이 PR #28(이슈 #15)도 머지되면 서브이슈 2개 + 에픽 모두 자동 종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)