### PR TITLE
feat: #3 데이터 레이어 — Task 트리 조회 + CRUD Server Action 스텁

### DIFF
--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -1,0 +1,46 @@
+'use server';
+
+// Task CRUD Server Action 시그니처 스텁.
+// 실제 DB 쿼리 본체는 에픽 5(5.1/5.2/5.2.1/5.3)에서 채운다.
+// 변경 성공 후에는 각 action 마지막에 revalidatePath('/') 를 호출해 목록 뷰를 갱신한다.
+
+export type CreateTaskInput = {
+  title: string;
+  parentId?: string | null;
+  description?: string | null;
+  assignee?: string | null;
+  startDate?: string | null;
+  dueDate?: string | null;
+};
+
+export type UpdateTaskPatch = Partial<{
+  title: string;
+  description: string | null;
+  assignee: string | null;
+  status: 'todo' | 'doing' | 'done';
+  progress: number;
+  startDate: string | null;
+  dueDate: string | null;
+  parentId: string | null;
+}>;
+
+export async function createTask(_input: CreateTaskInput): Promise<void> {
+  // TODO(5.1): insert into tasks, revalidatePath('/')
+  throw new Error('createTask: not implemented (will be filled in issue 5.1)');
+}
+
+export async function updateTask(_id: string, _patch: UpdateTaskPatch): Promise<void> {
+  // TODO(5.2): update tasks set ... where id = ?, revalidatePath('/')
+  // progress 100 → status 'done' 자동 동기화 규칙(SPEC.md §3)은 여기서 적용.
+  throw new Error('updateTask: not implemented (will be filled in issue 5.2)');
+}
+
+export async function deleteTask(_id: string): Promise<void> {
+  // TODO(5.3): delete from tasks where id = ? (cascade로 자식도 삭제), revalidatePath('/')
+  throw new Error('deleteTask: not implemented (will be filled in issue 5.3)');
+}
+
+export async function cycleStatus(_id: string): Promise<void> {
+  // TODO(5.2.1): todo → doing → done → todo 순회, revalidatePath('/')
+  throw new Error('cycleStatus: not implemented (will be filled in issue 5.2.1)');
+}

--- a/lib/tasks/queries.ts
+++ b/lib/tasks/queries.ts
@@ -1,0 +1,29 @@
+import 'server-only';
+import { asc } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+
+export type Task = typeof tasks.$inferSelect;
+export type TaskNode = Task & { children: TaskNode[] };
+
+export async function getTaskTree(): Promise<TaskNode[]> {
+  const rows = await db.select().from(tasks).orderBy(asc(tasks.createdAt));
+
+  const byId = new Map<string, TaskNode>();
+  for (const row of rows) {
+    byId.set(row.id, { ...row, children: [] });
+  }
+
+  const roots: TaskNode[] = [];
+  for (const node of byId.values()) {
+    // parentId 가 있어도 실제 부모 레코드가 없으면(고아) 루트로 올린다.
+    const parent = node.parentId ? byId.get(node.parentId) : undefined;
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  return roots;
+}


### PR DESCRIPTION
## Summary
- `lib/tasks/queries.ts` 추가 — `getTaskTree()`: `tasks` 전체를 `created_at` 오름차순으로 읽어 `parent_id` 기준 메모리 트리 구성 (고아 레코드는 루트로 승격)
- `app/actions/tasks.ts` 추가 — `createTask` / `updateTask` / `deleteTask` / `cycleStatus` Server Action 시그니처 스텁. 본체는 에픽 5(5.1/5.2/5.2.1/5.3)에서 구현, `revalidatePath('/')` 위치는 주석으로 명시
- 서브이슈 #17 / #18 은 규모가 작아(합계 2파일·75라인) 본 PR 하나로 통합 처리

## 설계 메모
- `lib/db/index.ts` 는 `server-only` 이므로 `queries.ts` 도 `server-only` import 로 클라이언트 번들 유입을 차단 (CLAUDE.md §2)
- `Task = typeof tasks.$inferSelect` 로 Drizzle 스키마와 타입을 일원화 — 4.1 / 5.x 가 바로 재사용
- 진행률 100 → 상태 `done` 자동 동기화(SPEC.md §3)는 5.2 `updateTask` 에서 구현 예정 — TODO 주석으로 위치 고정

## Test plan
- [x] `npm run build` 통과
- [x] `npm run lint` 통과 (ESLint: No issues found)
- [ ] 후속 4.1 에서 `getTaskTree()` import 하여 목록 뷰에 연결

Closes #3
Closes #17
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)