### PR TITLE
feat: #4 목록 뷰 — 빈 상태·Task 행·트리 토글

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,56 @@
-'use client';
+import { Box, Button, Flex, HStack, Heading, Stack, Text } from '@chakra-ui/react';
+import { TaskTree } from '@/components/task-tree';
+import { getTaskTree } from '@/lib/tasks/queries';
 
-import { Box, Button, Heading, Stack } from '@chakra-ui/react';
+// 목록은 항상 현재 DB 상태를 읽는다 — 빌드 타임 prerender 금지.
+export const dynamic = 'force-dynamic';
 
-export default function HomePage() {
+export default async function HomePage() {
+  const tasks = await getTaskTree();
+
   return (
     <Box as="main" p={8}>
-      <Stack gap={4}>
-        <Heading size="lg">WBS — 초기 스캐폴드</Heading>
-        <Button colorPalette="blue" alignSelf="flex-start">
-          Chakra 동작 확인
-        </Button>
+      <Stack gap={6}>
+        <Flex align="center" justify="space-between" wrap="wrap" gap={4}>
+          <HStack gap={4}>
+            <Heading size="lg">WBS</Heading>
+            <HStack
+              gap={0}
+              borderWidth="1px"
+              borderColor="gray.200"
+              borderRadius="md"
+              overflow="hidden"
+            >
+              <Button size="sm" variant="solid" colorPalette="blue" borderRadius={0}>
+                목록
+              </Button>
+              <Button size="sm" variant="ghost" borderRadius={0} aria-disabled>
+                간트
+              </Button>
+            </HStack>
+          </HStack>
+
+          <HStack gap={2}>
+            <Button size="sm" colorPalette="blue">
+              + 작업 추가
+            </Button>
+            <Button size="sm" variant="outline" aria-disabled>
+              CSV 내보내기
+            </Button>
+            <Button size="sm" variant="outline" aria-disabled>
+              CSV 불러오기
+            </Button>
+          </HStack>
+        </Flex>
+
+        {tasks.length === 0 ? (
+          <Stack align="center" gap={3} py={16}>
+            <Text color="gray.600">아직 작업이 없습니다. 첫 작업을 추가해 시작하세요</Text>
+            <Button colorPalette="blue">+ 작업 추가</Button>
+          </Stack>
+        ) : (
+          <TaskTree tasks={tasks} />
+        )}
       </Stack>
     </Box>
   );

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -1,0 +1,101 @@
+import { Badge, Box, Flex, IconButton, Progress, Text } from '@chakra-ui/react';
+import type { TaskNode } from '@/lib/tasks/queries';
+
+type Props = {
+  task: TaskNode;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  todo: '할 일',
+  doing: '진행 중',
+  done: '완료',
+};
+
+const STATUS_PALETTE: Record<string, string> = {
+  todo: 'gray',
+  doing: 'blue',
+  done: 'green',
+};
+
+function formatDate(iso: string): string {
+  // 'YYYY-MM-DD' → 'M/D'
+  const [, m, d] = iso.split('-');
+  return `${Number(m)}/${Number(d)}`;
+}
+
+function formatDateRange(start: string | null, due: string | null): string {
+  if (!start && !due) return '—';
+  if (start && due) return `${formatDate(start)} ~ ${formatDate(due)}`;
+  if (start) return `${formatDate(start)} ~`;
+  return `~ ${formatDate(due as string)}`;
+}
+
+export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props) {
+  const statusKey = STATUS_LABEL[task.status] ? task.status : 'todo';
+
+  return (
+    <Flex
+      align="center"
+      gap={3}
+      px={2}
+      py={2}
+      borderBottomWidth="1px"
+      borderColor="gray.200"
+      _hover={{ bg: 'gray.50' }}
+    >
+      <Box width="1.75rem" display="flex" justifyContent="center" flexShrink={0}>
+        {hasChildren ? (
+          <IconButton
+            aria-label={expanded ? '접기' : '펼치기'}
+            aria-expanded={expanded}
+            size="2xs"
+            variant="ghost"
+            onClick={onToggle}
+          >
+            {expanded ? '▼' : '▶'}
+          </IconButton>
+        ) : null}
+      </Box>
+
+      <Box flex="1" minW={0} pl={`${depth * 1.5}rem`}>
+        <Text truncate>{task.title}</Text>
+      </Box>
+
+      <Box width="6rem" flexShrink={0}>
+        {task.assignee ? (
+          <Text>{task.assignee}</Text>
+        ) : (
+          <Text color="gray.500">—</Text>
+        )}
+      </Box>
+
+      <Box width="5rem" flexShrink={0}>
+        <Badge colorPalette={STATUS_PALETTE[statusKey]}>{STATUS_LABEL[statusKey]}</Badge>
+      </Box>
+
+      <Flex width="8rem" flexShrink={0} align="center" gap={2}>
+        <Text fontSize="sm" width="2.75rem" textAlign="right">
+          {task.progress}%
+        </Text>
+        <Progress.Root value={task.progress} size="xs" flex="1">
+          <Progress.Track>
+            <Progress.Range />
+          </Progress.Track>
+        </Progress.Root>
+      </Flex>
+
+      <Box width="9rem" flexShrink={0}>
+        <Text
+          fontSize="sm"
+          color={task.startDate || task.dueDate ? undefined : 'gray.500'}
+        >
+          {formatDateRange(task.startDate, task.dueDate)}
+        </Text>
+      </Box>
+    </Flex>
+  );
+}

--- a/components/task-tree.tsx
+++ b/components/task-tree.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Box } from '@chakra-ui/react';
+import { useState } from 'react';
+import type { TaskNode } from '@/lib/tasks/queries';
+import { TaskRow } from './task-row';
+
+type Props = {
+  tasks: TaskNode[];
+};
+
+type FlatRow = {
+  node: TaskNode;
+  depth: number;
+  hasChildren: boolean;
+};
+
+function flatten(nodes: TaskNode[], expanded: Set<string>, depth = 0, acc: FlatRow[] = []): FlatRow[] {
+  for (const node of nodes) {
+    const hasChildren = node.children.length > 0;
+    acc.push({ node, depth, hasChildren });
+    if (hasChildren && expanded.has(node.id)) {
+      flatten(node.children, expanded, depth + 1, acc);
+    }
+  }
+  return acc;
+}
+
+function collectIdsWithChildren(nodes: TaskNode[], acc: Set<string> = new Set()): Set<string> {
+  for (const node of nodes) {
+    if (node.children.length > 0) {
+      acc.add(node.id);
+      collectIdsWithChildren(node.children, acc);
+    }
+  }
+  return acc;
+}
+
+export function TaskTree({ tasks }: Props) {
+  const [expanded, setExpanded] = useState<Set<string>>(() => collectIdsWithChildren(tasks));
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const rows = flatten(tasks, expanded);
+
+  return (
+    <Box borderWidth="1px" borderColor="gray.200" borderRadius="md">
+      {rows.map(({ node, depth, hasChildren }) => (
+        <TaskRow
+          key={node.id}
+          task={node}
+          depth={depth}
+          hasChildren={hasChildren}
+          expanded={expanded.has(node.id)}
+          onToggle={() => toggle(node.id)}
+        />
+      ))}
+    </Box>
+  );
+}


### PR DESCRIPTION
## 요약
- SPEC §1(작업 목록) + §5(계층) 렌더링을 구현. CRUD는 범위 밖(에픽 5).
- `app/page.tsx`: Server Component로 전환, 빈 상태 안내 ↔ `<TaskTree>` 분기. 툴바(+작업추가·CSV·간트)는 **시각적으로만** 노출 — 클릭 wiring은 에픽 5/6/7.
- `components/task-tree.tsx`: Client Component. 자식 있는 노드 id들을 `Set`에 담아 펼침/접힘 상태 관리. 초기값은 전부 펼침.
- `components/task-row.tsx`: 제목 / 담당자(없으면 회색 "—") / 상태 배지 / 진행률 % + 얇은 바 / 기간(`M/D ~ M/D` · 한쪽만 `M/D ~` / `~ M/D` · 둘 다 없음 `—`). 자식 있는 노드에만 ▼/▶ 토글(`aria-expanded`).
- DB 쿼리 의존하므로 `export const dynamic = 'force-dynamic'`.

## 완료 조건 (DoD)
- [x] `npm run build && npm run lint` 통과
- [x] J1 (빈 상태 안내 + 버튼 노출) — 코드 레벨에서 확인
- [x] J2 행 렌더 부분 — DB 씨드 후 육안 확인 필요 (아래 테스트 플랜)
- [x] J3 표시 부분 — 들여쓰기 + ▼ 아이콘
- [x] J4 토글 — ▼/▶ 전환 + 자식 숨김/복원

## Test plan
- [x] `/dev-server`로 로컬 기동
- [x] 빈 상태: "아직 작업이 없습니다…" + `+ 작업 추가` + CSV 버튼 노출 (J1)
- [x] Supabase Studio에서 tasks 2건 씨드 (부모-자식)
- [x] 부모 행이 담당자 "—" / 할 일 / 0% / 기간 "—"로 렌더 (J2)
- [x] 부모 왼쪽 ▼, 자식 행 들여쓰기 (J3)
- [x] ▼ 클릭 → ▶, 자식 숨김 / 다시 클릭 → 복원 (J4)

## 범위 밖 (의도적)
- 상태 배지 인라인 순환 (J6) — 에픽 5.2.1
- 진행률 100 → 상태 자동 완료 (J5) — 에픽 5.2
- Overdue "지남" 배지 / 빗금 (J9) — 에픽 8
- CSV · 간트 버튼 실제 동작 — 에픽 6 · 7

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)