### PR TITLE
feat: #5 Task CRUD — 모달·상태 배지·삭제 다이얼로그

### DIFF
--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -1,8 +1,9 @@
 'use server';
 
-// Task CRUD Server Action 시그니처 스텁.
-// 실제 DB 쿼리 본체는 에픽 5(5.1/5.2/5.2.1/5.3)에서 채운다.
-// 변경 성공 후에는 각 action 마지막에 revalidatePath('/') 를 호출해 목록 뷰를 갱신한다.
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { db } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
 
 export type CreateTaskInput = {
   title: string;
@@ -24,23 +25,55 @@ export type UpdateTaskPatch = Partial<{
   parentId: string | null;
 }>;
 
-export async function createTask(_input: CreateTaskInput): Promise<void> {
-  // TODO(5.1): insert into tasks, revalidatePath('/')
-  throw new Error('createTask: not implemented (will be filled in issue 5.1)');
+function emptyToNull<T extends string | null | undefined>(v: T): string | null {
+  if (v === undefined || v === null) return null;
+  const trimmed = v.trim();
+  return trimmed.length === 0 ? null : trimmed;
 }
 
-export async function updateTask(_id: string, _patch: UpdateTaskPatch): Promise<void> {
-  // TODO(5.2): update tasks set ... where id = ?, revalidatePath('/')
-  // progress 100 → status 'done' 자동 동기화 규칙(SPEC.md §3)은 여기서 적용.
-  throw new Error('updateTask: not implemented (will be filled in issue 5.2)');
+export async function createTask(input: CreateTaskInput): Promise<void> {
+  const title = input.title.trim();
+  if (!title) throw new Error('title is required');
+
+  await db.insert(tasks).values({
+    title,
+    parentId: emptyToNull(input.parentId ?? null),
+    description: emptyToNull(input.description),
+    assignee: emptyToNull(input.assignee),
+    startDate: emptyToNull(input.startDate),
+    dueDate: emptyToNull(input.dueDate),
+  });
+
+  revalidatePath('/');
 }
 
-export async function deleteTask(_id: string): Promise<void> {
-  // TODO(5.3): delete from tasks where id = ? (cascade로 자식도 삭제), revalidatePath('/')
-  throw new Error('deleteTask: not implemented (will be filled in issue 5.3)');
+export async function updateTask(id: string, patch: UpdateTaskPatch): Promise<void> {
+  // SPEC §3-2: 진행률 100 → 상태 자동 'done' (편의). 역방향(상태 → 진행률) 자동 동기화는 없다.
+  const next: Record<string, unknown> = { ...patch, updatedAt: new Date() };
+
+  if (patch.progress === 100) {
+    next.status = 'done';
+  }
+
+  if ('parentId' in patch) {
+    next.parentId = emptyToNull(patch.parentId ?? null);
+  }
+  if ('description' in patch) next.description = emptyToNull(patch.description);
+  if ('assignee' in patch) next.assignee = emptyToNull(patch.assignee);
+  if ('startDate' in patch) next.startDate = emptyToNull(patch.startDate);
+  if ('dueDate' in patch) next.dueDate = emptyToNull(patch.dueDate);
+  if (patch.title !== undefined) {
+    const t = patch.title.trim();
+    if (!t) throw new Error('title cannot be empty');
+    next.title = t;
+  }
+
+  await db.update(tasks).set(next).where(eq(tasks.id, id));
+  revalidatePath('/');
 }
 
-export async function cycleStatus(_id: string): Promise<void> {
-  // TODO(5.2.1): todo → doing → done → todo 순회, revalidatePath('/')
-  throw new Error('cycleStatus: not implemented (will be filled in issue 5.2.1)');
+export async function deleteTask(id: string): Promise<void> {
+  // FK ON DELETE CASCADE 가 자식 레코드까지 함께 제거한다 (lib/db/schema.ts).
+  await db.delete(tasks).where(eq(tasks.id, id));
+  revalidatePath('/');
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,6 @@
 import { Box, Button, Flex, HStack, Heading, Stack, Text } from '@chakra-ui/react';
+import { AddTaskButton } from '@/components/add-task-button';
+import { TaskActionsProvider } from '@/components/task-actions-provider';
 import { TaskTree } from '@/components/task-tree';
 import { getTaskTree } from '@/lib/tasks/queries';
 
@@ -9,49 +11,49 @@ export default async function HomePage() {
   const tasks = await getTaskTree();
 
   return (
-    <Box as="main" p={8}>
-      <Stack gap={6}>
-        <Flex align="center" justify="space-between" wrap="wrap" gap={4}>
-          <HStack gap={4}>
-            <Heading size="lg">WBS</Heading>
-            <HStack
-              gap={0}
-              borderWidth="1px"
-              borderColor="gray.200"
-              borderRadius="md"
-              overflow="hidden"
-            >
-              <Button size="sm" variant="solid" colorPalette="blue" borderRadius={0}>
-                목록
+    <TaskActionsProvider>
+      <Box as="main" p={8}>
+        <Stack gap={6}>
+          <Flex align="center" justify="space-between" wrap="wrap" gap={4}>
+            <HStack gap={4}>
+              <Heading size="lg">WBS</Heading>
+              <HStack
+                gap={0}
+                borderWidth="1px"
+                borderColor="gray.200"
+                borderRadius="md"
+                overflow="hidden"
+              >
+                <Button size="sm" variant="solid" colorPalette="blue" borderRadius={0}>
+                  목록
+                </Button>
+                <Button size="sm" variant="ghost" borderRadius={0} aria-disabled>
+                  간트
+                </Button>
+              </HStack>
+            </HStack>
+
+            <HStack gap={2}>
+              <AddTaskButton size="sm" />
+              <Button size="sm" variant="outline" aria-disabled>
+                CSV 내보내기
               </Button>
-              <Button size="sm" variant="ghost" borderRadius={0} aria-disabled>
-                간트
+              <Button size="sm" variant="outline" aria-disabled>
+                CSV 불러오기
               </Button>
             </HStack>
-          </HStack>
+          </Flex>
 
-          <HStack gap={2}>
-            <Button size="sm" colorPalette="blue">
-              + 작업 추가
-            </Button>
-            <Button size="sm" variant="outline" aria-disabled>
-              CSV 내보내기
-            </Button>
-            <Button size="sm" variant="outline" aria-disabled>
-              CSV 불러오기
-            </Button>
-          </HStack>
-        </Flex>
-
-        {tasks.length === 0 ? (
-          <Stack align="center" gap={3} py={16}>
-            <Text color="gray.600">아직 작업이 없습니다. 첫 작업을 추가해 시작하세요</Text>
-            <Button colorPalette="blue">+ 작업 추가</Button>
-          </Stack>
-        ) : (
-          <TaskTree tasks={tasks} />
-        )}
-      </Stack>
-    </Box>
+          {tasks.length === 0 ? (
+            <Stack align="center" gap={3} py={16}>
+              <Text color="gray.600">아직 작업이 없습니다. 첫 작업을 추가해 시작하세요</Text>
+              <AddTaskButton />
+            </Stack>
+          ) : (
+            <TaskTree tasks={tasks} />
+          )}
+        </Stack>
+      </Box>
+    </TaskActionsProvider>
   );
 }

--- a/components/add-task-button.tsx
+++ b/components/add-task-button.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { Button, type ButtonProps } from '@chakra-ui/react';
+import { useTaskActions } from './task-actions-provider';
+
+export function AddTaskButton(props: ButtonProps) {
+  const { openCreateRoot } = useTaskActions();
+  return (
+    <Button colorPalette="blue" {...props} onClick={openCreateRoot}>
+      + 작업 추가
+    </Button>
+  );
+}

--- a/components/confirm-dialog.tsx
+++ b/components/confirm-dialog.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Button, CloseButton, Dialog, Portal, Text } from '@chakra-ui/react';
+import { useTransition } from 'react';
+
+type Props = {
+  open: boolean;
+  title: string;
+  body: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => Promise<void> | void;
+  onClose: () => void;
+};
+
+export function ConfirmDialog({
+  open,
+  title,
+  body,
+  confirmLabel = '삭제',
+  cancelLabel = '취소',
+  onConfirm,
+  onClose,
+}: Props) {
+  const [pending, startTransition] = useTransition();
+
+  const handleConfirm = () => {
+    startTransition(async () => {
+      await onConfirm();
+      onClose();
+    });
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(d) => {
+        if (!d.open) onClose();
+      }}
+      role="alertdialog"
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>{title}</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Text>{body}</Text>
+            </Dialog.Body>
+            <Dialog.Footer gap={2}>
+              <Button variant="outline" onClick={onClose} disabled={pending}>
+                {cancelLabel}
+              </Button>
+              <Button colorPalette="red" onClick={handleConfirm} loading={pending}>
+                {confirmLabel}
+              </Button>
+            </Dialog.Footer>
+            <Dialog.CloseTrigger asChild>
+              <CloseButton size="sm" />
+            </Dialog.CloseTrigger>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/status-badge.tsx
+++ b/components/status-badge.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Badge, Menu, Portal } from '@chakra-ui/react';
+import { useTransition } from 'react';
+import { updateTask } from '@/app/actions/tasks';
+
+type StatusKey = 'todo' | 'doing' | 'done';
+
+const LABEL: Record<StatusKey, string> = {
+  todo: '할 일',
+  doing: '진행 중',
+  done: '완료',
+};
+
+const PALETTE: Record<StatusKey, string> = {
+  todo: 'gray',
+  doing: 'blue',
+  done: 'green',
+};
+
+const ORDER: StatusKey[] = ['todo', 'doing', 'done'];
+
+type Props = {
+  taskId: string;
+  status: string;
+};
+
+export function StatusBadge({ taskId, status }: Props) {
+  const [pending, startTransition] = useTransition();
+  const current: StatusKey = (LABEL as Record<string, string>)[status] ? (status as StatusKey) : 'todo';
+
+  const choose = (next: StatusKey) => {
+    if (next === current) return;
+    startTransition(() => {
+      void updateTask(taskId, { status: next });
+    });
+  };
+
+  return (
+    <Menu.Root
+      positioning={{ placement: 'bottom-start' }}
+      onSelect={(d) => choose(d.value as StatusKey)}
+    >
+      <Menu.Trigger
+        asChild
+        onClick={(e) => {
+          // 행 클릭(편집 모달 오픈)으로 버블링되지 않도록 차단.
+          e.stopPropagation();
+        }}
+      >
+        <Badge
+          colorPalette={PALETTE[current]}
+          cursor="pointer"
+          opacity={pending ? 0.6 : 1}
+          aria-label={`상태 변경: ${LABEL[current]}`}
+        >
+          {LABEL[current]}
+        </Badge>
+      </Menu.Trigger>
+      <Portal>
+        <Menu.Positioner>
+          <Menu.Content onClick={(e) => e.stopPropagation()}>
+            {ORDER.map((s) => (
+              <Menu.Item key={s} value={s}>
+                {LABEL[s]}
+              </Menu.Item>
+            ))}
+          </Menu.Content>
+        </Menu.Positioner>
+      </Portal>
+    </Menu.Root>
+  );
+}

--- a/components/task-actions-provider.tsx
+++ b/components/task-actions-provider.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import { deleteTask } from '@/app/actions/tasks';
+import type { Task, TaskNode } from '@/lib/tasks/queries';
+import { ConfirmDialog } from './confirm-dialog';
+import { TaskModal, type TaskModalMode } from './task-modal';
+
+type Ctx = {
+  openCreateRoot: () => void;
+  openCreateChild: (parent: Task) => void;
+  openEdit: (task: Task) => void;
+  openDelete: (task: TaskNode) => void;
+};
+
+const TaskActionsContext = createContext<Ctx | null>(null);
+
+export function useTaskActions(): Ctx {
+  const ctx = useContext(TaskActionsContext);
+  if (!ctx) throw new Error('useTaskActions must be used inside <TaskActionsProvider>');
+  return ctx;
+}
+
+function countDescendants(node: TaskNode): number {
+  let n = 0;
+  for (const child of node.children) {
+    n += 1 + countDescendants(child);
+  }
+  return n;
+}
+
+type DeleteState = { task: TaskNode; descendants: number } | null;
+
+export function TaskActionsProvider({ children }: { children: ReactNode }) {
+  const [modalMode, setModalMode] = useState<TaskModalMode | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [deleteState, setDeleteState] = useState<DeleteState>(null);
+
+  const openCreateRoot = useCallback(() => {
+    setModalMode({ kind: 'create' });
+    setModalOpen(true);
+  }, []);
+
+  const openCreateChild = useCallback((parent: Task) => {
+    setModalMode({ kind: 'create', parentId: parent.id, parentTitle: parent.title });
+    setModalOpen(true);
+  }, []);
+
+  const openEdit = useCallback((task: Task) => {
+    setModalMode({ kind: 'edit', task });
+    setModalOpen(true);
+  }, []);
+
+  const openDelete = useCallback((task: TaskNode) => {
+    setDeleteState({ task, descendants: countDescendants(task) });
+  }, []);
+
+  const value = useMemo<Ctx>(
+    () => ({ openCreateRoot, openCreateChild, openEdit, openDelete }),
+    [openCreateRoot, openCreateChild, openEdit, openDelete],
+  );
+
+  const closeModal = () => setModalOpen(false);
+  const closeDelete = () => setDeleteState(null);
+
+  const deleteBody = deleteState
+    ? deleteState.descendants > 0
+      ? `이 작업과 하위 작업 ${deleteState.descendants}개가 모두 삭제됩니다. 계속할까요?`
+      : '이 작업을 삭제합니다. 계속할까요?'
+    : '';
+
+  return (
+    <TaskActionsContext.Provider value={value}>
+      {children}
+      <TaskModal open={modalOpen} mode={modalMode} onClose={closeModal} />
+      <ConfirmDialog
+        open={!!deleteState}
+        title="작업 삭제"
+        body={deleteBody}
+        confirmLabel="삭제"
+        onConfirm={async () => {
+          if (deleteState) await deleteTask(deleteState.task.id);
+        }}
+        onClose={closeDelete}
+      />
+    </TaskActionsContext.Provider>
+  );
+}

--- a/components/task-modal.tsx
+++ b/components/task-modal.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import {
+  Button,
+  CloseButton,
+  Dialog,
+  Field,
+  HStack,
+  Input,
+  NativeSelect,
+  Portal,
+  Stack,
+  Textarea,
+} from '@chakra-ui/react';
+import { useEffect, useState, useTransition } from 'react';
+import { createTask, updateTask, type UpdateTaskPatch } from '@/app/actions/tasks';
+import type { Task } from '@/lib/tasks/queries';
+
+export type TaskModalMode =
+  | { kind: 'create'; parentId?: string | null; parentTitle?: string | null }
+  | { kind: 'edit'; task: Task };
+
+type Props = {
+  open: boolean;
+  mode: TaskModalMode | null;
+  onClose: () => void;
+};
+
+type FormState = {
+  title: string;
+  description: string;
+  assignee: string;
+  status: 'todo' | 'doing' | 'done';
+  progress: string; // input value as string for controlled component
+  startDate: string;
+  dueDate: string;
+};
+
+const EMPTY: FormState = {
+  title: '',
+  description: '',
+  assignee: '',
+  status: 'todo',
+  progress: '0',
+  startDate: '',
+  dueDate: '',
+};
+
+function fromTask(t: Task): FormState {
+  return {
+    title: t.title,
+    description: t.description ?? '',
+    assignee: t.assignee ?? '',
+    status: (t.status as FormState['status']) ?? 'todo',
+    progress: String(t.progress ?? 0),
+    startDate: t.startDate ?? '',
+    dueDate: t.dueDate ?? '',
+  };
+}
+
+type Errors = Partial<Record<'title' | 'progress' | 'dueDate', string>>;
+
+function validate(f: FormState): Errors {
+  const errs: Errors = {};
+  if (!f.title.trim()) errs.title = '제목은 필수입니다';
+
+  const p = Number(f.progress);
+  if (Number.isNaN(p) || p < 0 || p > 100) errs.progress = '진행률은 0~100 사이여야 합니다';
+
+  if (f.startDate && f.dueDate && f.startDate > f.dueDate) {
+    errs.dueDate = '목표 기한은 시작일 이후여야 합니다';
+  }
+
+  return errs;
+}
+
+export function TaskModal({ open, mode, onClose }: Props) {
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [errors, setErrors] = useState<Errors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  // 모드 변경 시 폼 초기화 (모달 열릴 때).
+  useEffect(() => {
+    if (!open || !mode) return;
+    setErrors({});
+    setSubmitError(null);
+    setForm(mode.kind === 'edit' ? fromTask(mode.task) : EMPTY);
+  }, [open, mode]);
+
+  if (!mode) return null;
+
+  const isEdit = mode.kind === 'edit';
+  const title = isEdit ? '작업 수정' : mode.parentId ? '하위 작업 추가' : '새 작업';
+
+  const set = <K extends keyof FormState>(k: K, v: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [k]: v }));
+  };
+
+  const submit = () => {
+    const errs = validate(form);
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
+
+    startTransition(async () => {
+      try {
+        if (mode.kind === 'create') {
+          await createTask({
+            title: form.title,
+            parentId: mode.parentId ?? null,
+            description: form.description || null,
+            assignee: form.assignee || null,
+            startDate: form.startDate || null,
+            dueDate: form.dueDate || null,
+          });
+        } else {
+          const patch: UpdateTaskPatch = {
+            title: form.title,
+            description: form.description || null,
+            assignee: form.assignee || null,
+            status: form.status,
+            progress: Number(form.progress),
+            startDate: form.startDate || null,
+            dueDate: form.dueDate || null,
+          };
+          await updateTask(mode.task.id, patch);
+        }
+        onClose();
+      } catch (e) {
+        setSubmitError(e instanceof Error ? e.message : '저장 중 오류가 발생했습니다');
+      }
+    });
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(d) => {
+        if (!d.open) onClose();
+      }}
+      size="md"
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>{title}</Dialog.Title>
+            </Dialog.Header>
+
+            <Dialog.Body>
+              <Stack gap={4}>
+                <Field.Root invalid={!!errors.title} required>
+                  <Field.Label>
+                    제목 <Field.RequiredIndicator />
+                  </Field.Label>
+                  <Input
+                    autoFocus
+                    value={form.title}
+                    onChange={(e) => set('title', e.target.value)}
+                    placeholder="예: 기획 회의"
+                  />
+                  {errors.title && <Field.ErrorText>{errors.title}</Field.ErrorText>}
+                </Field.Root>
+
+                <Field.Root>
+                  <Field.Label>설명</Field.Label>
+                  <Textarea
+                    rows={3}
+                    value={form.description}
+                    onChange={(e) => set('description', e.target.value)}
+                  />
+                </Field.Root>
+
+                <Field.Root>
+                  <Field.Label>담당자</Field.Label>
+                  <Input
+                    value={form.assignee}
+                    onChange={(e) => set('assignee', e.target.value)}
+                    placeholder="예: 김PM"
+                  />
+                </Field.Root>
+
+                <HStack gap={4} align="start">
+                  {isEdit && (
+                    <Field.Root>
+                      <Field.Label>상태</Field.Label>
+                      <NativeSelect.Root>
+                        <NativeSelect.Field
+                          value={form.status}
+                          onChange={(e) => set('status', e.target.value as FormState['status'])}
+                        >
+                          <option value="todo">할 일</option>
+                          <option value="doing">진행 중</option>
+                          <option value="done">완료</option>
+                        </NativeSelect.Field>
+                        <NativeSelect.Indicator />
+                      </NativeSelect.Root>
+                    </Field.Root>
+                  )}
+
+                  {isEdit && (
+                    <Field.Root invalid={!!errors.progress}>
+                      <Field.Label>진행률 (%)</Field.Label>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={form.progress}
+                        onChange={(e) => set('progress', e.target.value)}
+                      />
+                      {errors.progress && (
+                        <Field.ErrorText>{errors.progress}</Field.ErrorText>
+                      )}
+                    </Field.Root>
+                  )}
+                </HStack>
+
+                <HStack gap={4} align="start">
+                  <Field.Root>
+                    <Field.Label>시작일</Field.Label>
+                    <Input
+                      type="date"
+                      value={form.startDate}
+                      onChange={(e) => set('startDate', e.target.value)}
+                    />
+                  </Field.Root>
+
+                  <Field.Root invalid={!!errors.dueDate}>
+                    <Field.Label>목표 기한</Field.Label>
+                    <Input
+                      type="date"
+                      value={form.dueDate}
+                      onChange={(e) => set('dueDate', e.target.value)}
+                    />
+                    {errors.dueDate && <Field.ErrorText>{errors.dueDate}</Field.ErrorText>}
+                  </Field.Root>
+                </HStack>
+
+                {mode.kind === 'create' && mode.parentTitle && (
+                  <Field.Root>
+                    <Field.Label>상위 작업</Field.Label>
+                    <Input value={mode.parentTitle} readOnly />
+                  </Field.Root>
+                )}
+
+                {submitError && <Field.ErrorText>{submitError}</Field.ErrorText>}
+              </Stack>
+            </Dialog.Body>
+
+            <Dialog.Footer gap={2}>
+              <Button variant="outline" onClick={onClose} disabled={pending}>
+                취소
+              </Button>
+              <Button colorPalette="blue" onClick={submit} loading={pending}>
+                저장
+              </Button>
+            </Dialog.Footer>
+
+            <Dialog.CloseTrigger asChild>
+              <CloseButton size="sm" />
+            </Dialog.CloseTrigger>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -1,5 +1,9 @@
-import { Badge, Box, Flex, IconButton, Progress, Text } from '@chakra-ui/react';
+'use client';
+
+import { Box, Flex, IconButton, Menu, Portal, Progress, Text } from '@chakra-ui/react';
 import type { TaskNode } from '@/lib/tasks/queries';
+import { StatusBadge } from './status-badge';
+import { useTaskActions } from './task-actions-provider';
 
 type Props = {
   task: TaskNode;
@@ -7,18 +11,6 @@ type Props = {
   hasChildren: boolean;
   expanded: boolean;
   onToggle: () => void;
-};
-
-const STATUS_LABEL: Record<string, string> = {
-  todo: '할 일',
-  doing: '진행 중',
-  done: '완료',
-};
-
-const STATUS_PALETTE: Record<string, string> = {
-  todo: 'gray',
-  doing: 'blue',
-  done: 'green',
 };
 
 function formatDate(iso: string): string {
@@ -35,7 +27,7 @@ function formatDateRange(start: string | null, due: string | null): string {
 }
 
 export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props) {
-  const statusKey = STATUS_LABEL[task.status] ? task.status : 'todo';
+  const { openCreateChild, openEdit, openDelete } = useTaskActions();
 
   return (
     <Flex
@@ -46,6 +38,8 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
       borderBottomWidth="1px"
       borderColor="gray.200"
       _hover={{ bg: 'gray.50' }}
+      cursor="pointer"
+      onClick={() => openEdit(task)}
     >
       <Box width="1.75rem" display="flex" justifyContent="center" flexShrink={0}>
         {hasChildren ? (
@@ -54,7 +48,10 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
             aria-expanded={expanded}
             size="2xs"
             variant="ghost"
-            onClick={onToggle}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle();
+            }}
           >
             {expanded ? '▼' : '▶'}
           </IconButton>
@@ -74,7 +71,7 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
       </Box>
 
       <Box width="5rem" flexShrink={0}>
-        <Badge colorPalette={STATUS_PALETTE[statusKey]}>{STATUS_LABEL[statusKey]}</Badge>
+        <StatusBadge taskId={task.id} status={task.status} />
       </Box>
 
       <Flex width="8rem" flexShrink={0} align="center" gap={2}>
@@ -95,6 +92,38 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
         >
           {formatDateRange(task.startDate, task.dueDate)}
         </Text>
+      </Box>
+
+      <Box flexShrink={0}>
+        <Menu.Root
+          positioning={{ placement: 'bottom-end' }}
+          onSelect={(d) => {
+            if (d.value === 'edit') openEdit(task);
+            else if (d.value === 'add-child') openCreateChild(task);
+            else if (d.value === 'delete') openDelete(task);
+          }}
+        >
+          <Menu.Trigger asChild onClick={(e) => e.stopPropagation()}>
+            <IconButton
+              aria-label="작업 메뉴"
+              size="xs"
+              variant="ghost"
+            >
+              ⋯
+            </IconButton>
+          </Menu.Trigger>
+          <Portal>
+            <Menu.Positioner>
+              <Menu.Content onClick={(e) => e.stopPropagation()}>
+                <Menu.Item value="edit">수정</Menu.Item>
+                <Menu.Item value="add-child">하위 작업 추가</Menu.Item>
+                <Menu.Item value="delete" color="red.600">
+                  삭제
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Positioner>
+          </Portal>
+        </Menu.Root>
       </Box>
     </Flex>
   );

--- a/components/task-tree.tsx
+++ b/components/task-tree.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box } from '@chakra-ui/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { TaskNode } from '@/lib/tasks/queries';
 import { TaskRow } from './task-row';
 
@@ -38,6 +38,16 @@ function collectIdsWithChildren(nodes: TaskNode[], acc: Set<string> = new Set())
 
 export function TaskTree({ tasks }: Props) {
   const [expanded, setExpanded] = useState<Set<string>>(() => collectIdsWithChildren(tasks));
+
+  // 작업이 새로 자식을 갖게 되면(예: 5.0 하위 작업 추가 직후) 자동으로 펼친다.
+  // 사용자가 명시적으로 접은 노드는 그대로 둔다.
+  useEffect(() => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      for (const id of collectIdsWithChildren(tasks)) next.add(id);
+      return next;
+    });
+  }, [tasks]);
 
   const toggle = (id: string) => {
     setExpanded((prev) => {


### PR DESCRIPTION
# 작업 내역

SPEC §2~§4 (B 생성 / C 수정 / D 삭제) 본체. 모달 중심 UX + 상태 배지 인라인 메뉴 + 진행률 100 → 상태 자동 완료.

- `app/actions/tasks.ts`: `createTask` / `updateTask` / `deleteTask` 본문. 빈 문자열을 null로 정규화. 진행률 100 → 상태 자동 'done' (역방향 없음). 자식은 FK `ON DELETE CASCADE`로 함께 삭제.
- 신규 컴포넌트 4종 (`task-modal`, `status-badge`, `confirm-dialog`, `task-actions-provider`) + `add-task-button`.
- `task-row`에 ⋯ 메뉴(수정 / 하위 작업 추가 / 삭제) + 행 클릭으로 수정 모달.
- `task-tree`는 새로 자식이 생긴 노드를 자동 펼침 (J3).
- `app/page.tsx`는 `<TaskActionsProvider>`로 wrap, "+ 작업 추가" 버튼 두 곳을 wiring.

---

## 1. 작업 생성·수정·삭제

- 모달은 생성·수정 단일 컴포넌트. `useState` + 수동 검증(제목 필수, progress 0~100, startDate ≤ dueDate). 폼 라이브러리(react-hook-form/zod)는 도입하지 않음.
- 상태 배지는 Chakra v3 `Menu.Root` + `onSelect` 패턴. (`onClick` 패턴은 메뉴 닫힘과 race가 있어 다이얼로그가 안 열리는 케이스가 있었음 → onSelect로 일원화.)
- 삭제 다이얼로그 본문은 자식 개수에 따라 `이 작업과 하위 작업 N개가 모두 삭제됩니다. 계속할까요?` / `이 작업을 삭제합니다. 계속할까요?` 분기.

---

## 2. 진행률 ↔ 상태 자동 동기화 규칙 (SPEC §3-2)

- 진행률 100 입력 → 상태가 자동으로 `완료`로 바뀜.
- 상태를 `완료`로 바꿔도 진행률은 자동으로 100이 되지 않음 (역방향 X).
- 상태를 `할 일`로 되돌려도 진행률은 0이 되지 않음.

---

# 테스트케이스

사전 조건: `npm install && npm run db:migrate` 후 `npm run dev`.

| 테스트명 | 테스트 방법 | 예상(기대) 결과 |
| :--- | :--- | :--- |
| J2 | 상단 `+ 작업 추가` → 제목/담당자/날짜 입력 → 저장 | 모달 닫히고 새 행이 즉시 목록에 등장 |
| J3 | 행 ⋯ → 하위 작업 추가 → 제목 입력 → 저장 | 부모 행에 ▼ 등장 + 들여쓰기된 자식 행이 자동 펼쳐진 채 표시 |
| J5 | 수정 모달에서 진행률 100 입력 → 저장 | 행 진행률 100% + 상태 배지 자동 `완료` |
| J6 | 행의 상태 배지 클릭 → 메뉴에서 다른 상태 선택 | 모달 안 열림. 배지가 즉시 바뀜. 진행률은 그대로 (역방향 동기화 없음) |
| J7 | 행 클릭 → 모달에서 제목 변경 → 저장 | 행 제목이 즉시 갱신 |
| J8 | 자식 가진 행 ⋯ → 삭제 → "하위 작업 N개가 모두 삭제됩니다" 확인 → 삭제 | 부모와 자식 모두 사라짐. 새로고침 후에도 미복구 |
| J17 | 신규 작업 모달에서 시작일 5/10, 목표 기한 5/5 입력 → 저장 | 저장 안 됨. 목표 기한 필드 아래 "목표 기한은 시작일 이후여야 합니다" |

로컬 회귀(Playwright MCP) 결과: J2/J3/J5/J6/J7/J8/J17 모두 통과.

`npm run lint`: No issues. `npm run build`: Compiled successfully.

Closes #5