### PR TITLE
feat: #8 Overdue 시각 표시 — 목록 경고색·배지 + 간트 테두리

### DIFF
--- a/components/gantt-bar.tsx
+++ b/components/gantt-bar.tsx
@@ -6,6 +6,7 @@ type Props = {
   progress: number;
   timelineStart: Date;
   timelineEnd: Date;
+  isOverdue?: boolean;
 };
 
 function clampPercent(value: number): number {
@@ -15,7 +16,7 @@ function clampPercent(value: number): number {
   return value;
 }
 
-export function GanttBar({ start, end, progress, timelineStart, timelineEnd }: Props) {
+export function GanttBar({ start, end, progress, timelineStart, timelineEnd, isOverdue = false }: Props) {
   const totalMs = timelineEnd.getTime() - timelineStart.getTime();
   if (totalMs <= 0) return null;
 
@@ -40,6 +41,7 @@ export function GanttBar({ start, end, progress, timelineStart, timelineEnd }: P
       overflow="hidden"
       userSelect="none"
       aria-label="간트 막대"
+      {...(isOverdue && { outline: '2px solid', outlineColor: 'red.500' })}
     >
       <Box width={`${fill}%`} height="100%" bg="blue.500" />
     </Box>

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 import type { TaskNode } from '@/lib/tasks/queries';
+import { isOverdue } from '@/lib/tasks/overdue';
 import { GanttBar } from './gantt-bar';
 
 type Props = {
@@ -183,6 +184,7 @@ export function GanttView({ tasks }: Props) {
                     progress={node.progress}
                     timelineStart={timelineStart}
                     timelineEnd={timelineEnd}
+                    isOverdue={isOverdue(node.dueDate, node.status)}
                   />
                 ) : (
                   <Flex position="absolute" inset={0} align="center" pl={3}>

--- a/components/overdue-indicator.tsx
+++ b/components/overdue-indicator.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { Badge } from '@chakra-ui/react';
+
+export function OverdueIndicator() {
+  return (
+    <Badge colorPalette="red" size="sm" variant="solid">
+      지남
+    </Badge>
+  );
+}

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -2,6 +2,8 @@
 
 import { Box, Flex, IconButton, Menu, Portal, Progress, Text } from '@chakra-ui/react';
 import type { TaskNode } from '@/lib/tasks/queries';
+import { isOverdue } from '@/lib/tasks/overdue';
+import { OverdueIndicator } from './overdue-indicator';
 import { StatusBadge } from './status-badge';
 import { useTaskActions } from './task-actions-provider';
 
@@ -86,12 +88,20 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
       </Flex>
 
       <Box width="9rem" flexShrink={0}>
-        <Text
-          fontSize="sm"
-          color={task.startDate || task.dueDate ? undefined : 'gray.500'}
-        >
-          {formatDateRange(task.startDate, task.dueDate)}
-        </Text>
+        {(() => {
+          const overdue = isOverdue(task.dueDate, task.status);
+          return (
+            <Flex align="center" gap={1} wrap="wrap">
+              <Text
+                fontSize="sm"
+                color={overdue ? 'red.500' : task.startDate || task.dueDate ? undefined : 'gray.500'}
+              >
+                {formatDateRange(task.startDate, task.dueDate)}
+              </Text>
+              {overdue && <OverdueIndicator />}
+            </Flex>
+          );
+        })()}
       </Box>
 
       <Box flexShrink={0}>

--- a/lib/tasks/overdue.ts
+++ b/lib/tasks/overdue.ts
@@ -1,0 +1,7 @@
+// today > dueDate AND status !== 'done'
+export function isOverdue(dueDate: string | null, status: string): boolean {
+  if (!dueDate || status === 'done') return false;
+  const today = new Date();
+  const todayIso = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+  return todayIso > dueDate;
+}


### PR DESCRIPTION
## Summary
- `lib/tasks/overdue.ts`: `isOverdue(dueDate, status)` 판정 함수 (오늘 > 기한 AND 상태 ≠ 완료)
- `components/overdue-indicator.tsx`: "지남" 빨간 배지 컴포넌트
- 목록 뷰: 기한 텍스트 빨간색 + "지남" 배지 → 상태를 완료로 바꾸면 즉시 해제
- 간트 뷰: Overdue 막대에 빨간 outline → 상태 변경 시 해제

## Test plan
- [x] J9: 기한이 지난 미완료 작업 → 목록에서 기한 텍스트 빨강 + "지남" 배지 확인
- [x] J9: 해당 작업 상태를 "완료"로 변경 → 배지·경고색 즉시 사라짐 확인
- [x] J15: 간트 뷰에서 같은 작업의 막대에 빨간 테두리 확인
- [x] J15: 완료 전환 시 간트 막대 테두리 사라짐 확인

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)