### PR TITLE
[feat] #6 CSV Import/Export (6.0 에픽)

### DIFF
--- a/app/api/csv/export/route.ts
+++ b/app/api/csv/export/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { buildCsvContent } from '@/lib/csv/export';
+
+export async function GET() {
+  const csv = await buildCsvContent();
+  const today = new Date().toISOString().split('T')[0];
+
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="wbs-${today}.csv"`,
+    },
+  });
+}

--- a/app/api/csv/import/route.ts
+++ b/app/api/csv/import/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+import { db } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+import { parseCsv, type ImportWarning } from '@/lib/csv/import';
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const action = formData.get('action') as string;
+  const file = formData.get('file') as File | null;
+
+  if (!file) {
+    return NextResponse.json({ error: 'no file' }, { status: 400 });
+  }
+
+  const text = await file.text();
+  const { valid, excluded } = parseCsv(text);
+
+  if (action === 'preview') {
+    // 기존 Task 제목 목록으로 parentTitle 매칭 여부 확인
+    const existing = await db.select({ title: tasks.title }).from(tasks);
+    const existingTitles = new Set(existing.map((t) => t.title));
+    const csvTitles = new Set(valid.map((r) => r.title));
+
+    const warnings: ImportWarning[] = [];
+    for (const row of valid) {
+      if (row.parentTitle && !existingTitles.has(row.parentTitle) && !csvTitles.has(row.parentTitle)) {
+        warnings.push({ title: row.title, message: '상위 매칭 실패 → 최상위로 처리' });
+      }
+    }
+
+    return NextResponse.json({ valid, excluded, warnings });
+  }
+
+  if (action === 'apply') {
+    const existing = await db.select({ id: tasks.id, title: tasks.title }).from(tasks);
+    const titleToId = new Map<string, string>();
+    for (const t of existing) {
+      if (!titleToId.has(t.title)) titleToId.set(t.title, t.id);
+    }
+
+    // 배치 내 순서대로 삽입해 CSV 내부 부모→자식 참조를 해소
+    for (const row of valid) {
+      let parentId: string | null = null;
+      if (row.parentTitle) {
+        parentId = titleToId.get(row.parentTitle) ?? null;
+      }
+
+      const [inserted] = await db
+        .insert(tasks)
+        .values({
+          title: row.title,
+          description: row.description,
+          assignee: row.assignee,
+          status: row.status,
+          progress: row.progress,
+          startDate: row.startDate,
+          dueDate: row.dueDate,
+          parentId,
+        })
+        .returning({ id: tasks.id });
+
+      if (inserted && !titleToId.has(row.title)) {
+        titleToId.set(row.title, inserted.id);
+      }
+    }
+
+    revalidatePath('/');
+    return NextResponse.json({ inserted: valid.length });
+  }
+
+  return NextResponse.json({ error: 'unknown action' }, { status: 400 });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,7 @@
-import { Box, Button, Flex, HStack, Heading, Stack, Text } from '@chakra-ui/react';
+import { Box, Flex, HStack, Heading, Stack, Text } from '@chakra-ui/react';
 import { AddTaskButton } from '@/components/add-task-button';
+import { CsvExportButton } from '@/components/csv-export-button';
+import { CsvImportDialog } from '@/components/csv-import-dialog';
 import { TaskActionsProvider } from '@/components/task-actions-provider';
 import { TaskTree } from '@/components/task-tree';
 import { ViewToggle } from '@/components/view-toggle';
@@ -23,12 +25,8 @@ export default async function HomePage() {
 
             <HStack gap={2}>
               <AddTaskButton size="sm" />
-              <Button size="sm" variant="outline" aria-disabled>
-                CSV 내보내기
-              </Button>
-              <Button size="sm" variant="outline" aria-disabled>
-                CSV 불러오기
-              </Button>
+              <CsvExportButton />
+              <CsvImportDialog />
             </HStack>
           </Flex>
 

--- a/components/csv-export-button.tsx
+++ b/components/csv-export-button.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { Button } from '@chakra-ui/react';
+
+export function CsvExportButton() {
+  return (
+    <Button size="sm" variant="outline" onClick={() => { window.location.href = '/api/csv/export'; }}>
+      CSV 내보내기
+    </Button>
+  );
+}

--- a/components/csv-import-dialog.tsx
+++ b/components/csv-import-dialog.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import {
+  Button,
+  CloseButton,
+  Dialog,
+  Portal,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+import { useRef, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import type { ImportRow, ExcludedRow, ImportWarning } from '@/lib/csv/import';
+
+type PreviewData = {
+  valid: ImportRow[];
+  excluded: ExcludedRow[];
+  warnings: ImportWarning[];
+};
+
+export function CsvImportDialog() {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFile(f);
+
+    const fd = new FormData();
+    fd.append('file', f);
+    fd.append('action', 'preview');
+
+    const res = await fetch('/api/csv/import', { method: 'POST', body: fd });
+    const data: PreviewData = await res.json();
+    setPreview(data);
+    setOpen(true);
+  };
+
+  const handleApply = () => {
+    if (!file) return;
+    startTransition(async () => {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('action', 'apply');
+      await fetch('/api/csv/import', { method: 'POST', body: fd });
+      handleClose();
+      router.refresh();
+    });
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setPreview(null);
+    setFile(null);
+    if (fileRef.current) fileRef.current.value = '';
+  };
+
+  return (
+    <>
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".csv"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
+      <Button size="sm" variant="outline" onClick={() => fileRef.current?.click()}>
+        CSV 불러오기
+      </Button>
+
+      <Dialog.Root
+        open={open}
+        onOpenChange={(d) => { if (!d.open) handleClose(); }}
+        size="md"
+      >
+        <Portal>
+          <Dialog.Backdrop />
+          <Dialog.Positioner>
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>CSV 가져오기 미리보기</Dialog.Title>
+              </Dialog.Header>
+
+              <Dialog.Body>
+                {preview && (
+                  <Stack gap={4}>
+                    <Text fontWeight="bold">
+                      {preview.valid.length}개 작업을 추가합니다. 제외 {preview.excluded.length}건
+                    </Text>
+
+                    {preview.excluded.length > 0 && (
+                      <Stack gap={1}>
+                        <Text fontSize="sm" fontWeight="semibold" color="red.600">
+                          제외 항목
+                        </Text>
+                        {preview.excluded.map((ex) => (
+                          <Text key={ex.lineNumber} fontSize="sm" color="red.500">
+                            {ex.lineNumber}행: {ex.reason}
+                          </Text>
+                        ))}
+                      </Stack>
+                    )}
+
+                    {preview.warnings.length > 0 && (
+                      <Stack gap={1}>
+                        <Text fontSize="sm" fontWeight="semibold" color="orange.600">
+                          경고
+                        </Text>
+                        {preview.warnings.map((w, i) => (
+                          <Text key={i} fontSize="sm" color="orange.500">
+                            &ldquo;{w.title}&rdquo;: {w.message}
+                          </Text>
+                        ))}
+                      </Stack>
+                    )}
+                  </Stack>
+                )}
+              </Dialog.Body>
+
+              <Dialog.Footer gap={2}>
+                <Button variant="outline" onClick={handleClose} disabled={pending}>
+                  취소
+                </Button>
+                <Button
+                  colorPalette="blue"
+                  onClick={handleApply}
+                  loading={pending}
+                  disabled={!preview?.valid.length}
+                >
+                  적용
+                </Button>
+              </Dialog.Footer>
+
+              <Dialog.CloseTrigger asChild>
+                <CloseButton size="sm" />
+              </Dialog.CloseTrigger>
+            </Dialog.Content>
+          </Dialog.Positioner>
+        </Portal>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/lib/csv/export.ts
+++ b/lib/csv/export.ts
@@ -1,0 +1,49 @@
+import 'server-only';
+import { asc } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+
+const STATUS_LABEL: Record<string, string> = {
+  todo: '할 일',
+  doing: '진행 중',
+  done: '완료',
+};
+
+export const CSV_HEADERS = ['제목', '설명', '담당자', '상태', '진행률', '시작일', '목표 기한', '상위 작업 제목'];
+
+function escapeCsv(value: string | null | undefined): string {
+  const v = value ?? '';
+  if (v.includes(',') || v.includes('"') || v.includes('\n') || v.includes('\r')) {
+    return `"${v.replace(/"/g, '""')}"`;
+  }
+  return v;
+}
+
+export async function buildCsvContent(): Promise<string> {
+  const rows = await db.select().from(tasks).orderBy(asc(tasks.createdAt));
+
+  const titleById = new Map<string, string>();
+  for (const row of rows) {
+    titleById.set(row.id, row.title);
+  }
+
+  const lines: string[] = [CSV_HEADERS.join(',')];
+
+  for (const row of rows) {
+    const parentTitle = row.parentId ? (titleById.get(row.parentId) ?? '') : '';
+    lines.push(
+      [
+        escapeCsv(row.title),
+        escapeCsv(row.description),
+        escapeCsv(row.assignee),
+        escapeCsv(STATUS_LABEL[row.status] ?? row.status),
+        String(row.progress),
+        escapeCsv(row.startDate),
+        escapeCsv(row.dueDate),
+        escapeCsv(parentTitle),
+      ].join(','),
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/lib/csv/import.ts
+++ b/lib/csv/import.ts
@@ -1,0 +1,113 @@
+export type ImportRow = {
+  title: string;
+  description: string | null;
+  assignee: string | null;
+  status: 'todo' | 'doing' | 'done';
+  progress: number;
+  startDate: string | null;
+  dueDate: string | null;
+  parentTitle: string | null;
+};
+
+export type ExcludedRow = {
+  lineNumber: number;
+  reason: string;
+};
+
+export type ImportWarning = {
+  title: string;
+  message: string;
+};
+
+export type ParseResult = {
+  valid: ImportRow[];
+  excluded: ExcludedRow[];
+};
+
+const STATUS_MAP: Record<string, 'todo' | 'doing' | 'done'> = {
+  '할 일': 'todo',
+  '진행 중': 'doing',
+  완료: 'done',
+};
+
+function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',') {
+        result.push(current.trim());
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+  }
+  result.push(current.trim());
+  return result;
+}
+
+function isValidDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s) && !isNaN(Date.parse(s));
+}
+
+export function parseCsv(csvText: string): ParseResult {
+  const lines = csvText.split('\n').map((l) => l.replace(/\r$/, ''));
+  const nonEmpty = lines.filter((l) => l.trim());
+
+  if (nonEmpty.length < 2) {
+    return { valid: [], excluded: [] };
+  }
+
+  const valid: ImportRow[] = [];
+  const excluded: ExcludedRow[] = [];
+
+  // index 0 is header, data starts at index 1
+  for (let i = 1; i < nonEmpty.length; i++) {
+    const lineNumber = i + 1;
+    const cols = parseCsvLine(nonEmpty[i]);
+    const [titleRaw, description, assignee, statusRaw, progressRaw, startDateRaw, dueDateRaw, parentTitleRaw] = cols;
+
+    if (!titleRaw || !titleRaw.trim()) {
+      excluded.push({ lineNumber, reason: '제목 누락' });
+      continue;
+    }
+
+    const status = STATUS_MAP[statusRaw?.trim() ?? ''] ?? 'todo';
+    const progress = Math.min(100, Math.max(0, parseInt(progressRaw ?? '0', 10) || 0));
+
+    const startDate =
+      startDateRaw?.trim() && isValidDate(startDateRaw.trim()) ? startDateRaw.trim() : null;
+    const dueDate =
+      dueDateRaw?.trim() && isValidDate(dueDateRaw.trim()) ? dueDateRaw.trim() : null;
+
+    valid.push({
+      title: titleRaw.trim(),
+      description: description?.trim() || null,
+      assignee: assignee?.trim() || null,
+      status,
+      progress,
+      startDate,
+      dueDate,
+      parentTitle: parentTitleRaw?.trim() || null,
+    });
+  }
+
+  return { valid, excluded };
+}


### PR DESCRIPTION
## Summary

- `lib/csv/export.ts` — DB Task 전체를 지정 헤더 순서로 CSV 생성
- `lib/csv/import.ts` — CSV 파싱 + 제목 누락·날짜 불량 유효성 검사
- `app/api/csv/export/route.ts` — GET → wbs-YYYY-MM-DD.csv 다운로드
- `app/api/csv/import/route.ts` — POST(preview/apply): parentTitle DB 매칭 경고 포함
- `components/csv-export-button.tsx` / `csv-import-dialog.tsx` — 버튼 + 미리보기 다이얼로그
- `app/page.tsx` — placeholder 버튼을 실제 컴포넌트로 교체

## Test plan

- [ ] J10: CSV 내보내기 → wbs-YYYY-MM-DD.csv 다운로드, 헤더 및 데이터 행 확인
- [ ] J11: 정상 CSV 가져오기 → "3개 추가, 제외 0건" → 적용 후 목록·계층 반영
- [ ] J12: 부분 오류 CSV → "제외 1건(제목 누락)", QA 행 "상위 매칭 실패 → 최상위" 경고

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)