### PR TITLE
docs: #22 README 상단에 배포 URL 기재

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude Code × Vercel WBS 과제
 
+🚀 **배포 URL**: <https://claude-vercel-wbs-sage.vercel.app>
+
 Claude Code만으로 WBS(Work Breakdown Structure) 프로젝트 매니지먼트 웹앱을 만들고, Vercel에 배포해 공개 URL을 획득해보는 풀스택 과제입니다. 직접 타이핑은 최소한으로만 하고, 대부분의 구현은 Claude Code에게 지시해서 진행합니다.
 
 ## 관련 문서


### PR DESCRIPTION
## Summary
- 9.4 — 과제 제출용 공개 URL(`https://claude-vercel-wbs-sage.vercel.app`)을 README 최상단에 노출
- 9.0 배포 에픽 마무리

## Test plan
- [x] README 미리보기에서 URL이 한눈에 보임
- [x] 링크 클릭 시 정상 접속 (배포 확인 완료)

Closes #22