### PR TITLE
fix+feat: #43 클릭 freeze 해결 + #44 글로벌 프로그레스바

### DIFF
--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,13 @@
+import { Box, Progress } from '@chakra-ui/react';
+
+export default function Loading() {
+  return (
+    <Box position="fixed" top={0} left={0} right={0} zIndex={9999}>
+      <Progress.Root value={null} size="xs" colorPalette="blue">
+        <Progress.Track borderRadius={0}>
+          <Progress.Range />
+        </Progress.Track>
+      </Progress.Root>
+    </Box>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,7 +2,12 @@
 
 import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
 import type { ReactNode } from 'react';
+import { ProgressProvider } from '@/components/progress-provider';
 
 export function Providers({ children }: { children: ReactNode }) {
-  return <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>;
+  return (
+    <ChakraProvider value={defaultSystem}>
+      <ProgressProvider>{children}</ProgressProvider>
+    </ChakraProvider>
+  );
 }

--- a/components/confirm-dialog.tsx
+++ b/components/confirm-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { Button, CloseButton, Dialog, Portal, Text } from '@chakra-ui/react';
 import { useEffect, useRef, useState, useTransition } from 'react';
+import { useGlobalProgress } from './progress-provider';
 
 type Props = {
   open: boolean;
@@ -26,10 +27,12 @@ export function ConfirmDialog({
   // close 를 transition 외부에서 수행해 Chakra Dialog cleanup 과 RSC 커밋의 경합을 막는다 (#43).
   const submittingRef = useRef(false);
   const [confirmError, setConfirmError] = useState(false);
+  const progress = useGlobalProgress();
 
   const handleConfirm = () => {
     setConfirmError(false);
     submittingRef.current = true;
+    progress.begin();
     startTransition(async () => {
       try {
         await onConfirm();
@@ -43,9 +46,10 @@ export function ConfirmDialog({
     if (pending) return;
     if (!submittingRef.current) return;
     submittingRef.current = false;
+    progress.end();
     if (confirmError) return;
     onClose();
-  }, [pending, confirmError, onClose]);
+  }, [pending, confirmError, onClose, progress]);
 
   return (
     <Dialog.Root

--- a/components/confirm-dialog.tsx
+++ b/components/confirm-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, CloseButton, Dialog, Portal, Text } from '@chakra-ui/react';
-import { useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 
 type Props = {
   open: boolean;
@@ -23,13 +23,29 @@ export function ConfirmDialog({
   onClose,
 }: Props) {
   const [pending, startTransition] = useTransition();
+  // close 를 transition 외부에서 수행해 Chakra Dialog cleanup 과 RSC 커밋의 경합을 막는다 (#43).
+  const submittingRef = useRef(false);
+  const [confirmError, setConfirmError] = useState(false);
 
   const handleConfirm = () => {
+    setConfirmError(false);
+    submittingRef.current = true;
     startTransition(async () => {
-      await onConfirm();
-      onClose();
+      try {
+        await onConfirm();
+      } catch {
+        setConfirmError(true);
+      }
     });
   };
+
+  useEffect(() => {
+    if (pending) return;
+    if (!submittingRef.current) return;
+    submittingRef.current = false;
+    if (confirmError) return;
+    onClose();
+  }, [pending, confirmError, onClose]);
 
   return (
     <Dialog.Root

--- a/components/global-progress.tsx
+++ b/components/global-progress.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Box, Progress } from '@chakra-ui/react';
+
+type Props = {
+  active: boolean;
+};
+
+export function GlobalProgress({ active }: Props) {
+  if (!active) return null;
+  return (
+    <Box
+      position="fixed"
+      top={0}
+      left={0}
+      right={0}
+      zIndex={9999}
+      pointerEvents="none"
+      aria-hidden="true"
+    >
+      <Progress.Root value={null} size="xs" colorPalette="blue">
+        <Progress.Track borderRadius={0}>
+          <Progress.Range />
+        </Progress.Track>
+      </Progress.Root>
+    </Box>
+  );
+}

--- a/components/progress-provider.tsx
+++ b/components/progress-provider.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { GlobalProgress } from './global-progress';
+
+type Ctx = {
+  begin: () => void;
+  end: () => void;
+};
+
+const ProgressContext = createContext<Ctx | null>(null);
+
+export function useGlobalProgress(): Ctx {
+  const ctx = useContext(ProgressContext);
+  if (!ctx) throw new Error('useGlobalProgress must be used inside <ProgressProvider>');
+  return ctx;
+}
+
+export function ProgressProvider({ children }: { children: ReactNode }) {
+  const [count, setCount] = useState(0);
+
+  const begin = useCallback(() => setCount((c) => c + 1), []);
+  const end = useCallback(() => setCount((c) => Math.max(0, c - 1)), []);
+
+  const value = useMemo<Ctx>(() => ({ begin, end }), [begin, end]);
+
+  return (
+    <ProgressContext.Provider value={value}>
+      <GlobalProgress active={count > 0} />
+      {children}
+    </ProgressContext.Provider>
+  );
+}

--- a/components/task-actions-provider.tsx
+++ b/components/task-actions-provider.tsx
@@ -35,6 +35,7 @@ export function TaskActionsProvider({ children }: { children: ReactNode }) {
   const [modalMode, setModalMode] = useState<TaskModalMode | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [deleteState, setDeleteState] = useState<DeleteState>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   const openCreateRoot = useCallback(() => {
     setModalMode({ kind: 'create' });
@@ -53,6 +54,7 @@ export function TaskActionsProvider({ children }: { children: ReactNode }) {
 
   const openDelete = useCallback((task: TaskNode) => {
     setDeleteState({ task, descendants: countDescendants(task) });
+    setDeleteOpen(true);
   }, []);
 
   const value = useMemo<Ctx>(
@@ -60,8 +62,17 @@ export function TaskActionsProvider({ children }: { children: ReactNode }) {
     [openCreateRoot, openCreateChild, openEdit, openDelete],
   );
 
-  const closeModal = () => setModalOpen(false);
-  const closeDelete = () => setDeleteState(null);
+  // close 후 mode/state 클리어를 Dialog 의 close 애니메이션이 끝난 뒤로 미룬다.
+  // 즉시 클리어하면 Chakra Dialog 가 언마운트 도중 stale mode 를 다시 그리려 시도해
+  // inert/aria-hidden 정리가 어긋나는 경우가 있다 (#43).
+  const closeModal = useCallback(() => {
+    setModalOpen(false);
+    window.setTimeout(() => setModalMode(null), 300);
+  }, []);
+  const closeDelete = useCallback(() => {
+    setDeleteOpen(false);
+    window.setTimeout(() => setDeleteState(null), 300);
+  }, []);
 
   const deleteBody = deleteState
     ? deleteState.descendants > 0
@@ -74,7 +85,7 @@ export function TaskActionsProvider({ children }: { children: ReactNode }) {
       {children}
       <TaskModal open={modalOpen} mode={modalMode} onClose={closeModal} />
       <ConfirmDialog
-        open={!!deleteState}
+        open={deleteOpen}
         title="작업 삭제"
         body={deleteBody}
         confirmLabel="삭제"

--- a/components/task-modal.tsx
+++ b/components/task-modal.tsx
@@ -12,7 +12,7 @@ import {
   Stack,
   Textarea,
 } from '@chakra-ui/react';
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 import { createTask, updateTask, type UpdateTaskPatch } from '@/app/actions/tasks';
 import type { Task } from '@/lib/tasks/queries';
 
@@ -79,6 +79,10 @@ export function TaskModal({ open, mode, onClose }: Props) {
   const [errors, setErrors] = useState<Errors>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  // submit() 가 트랜지션을 시작했음을 표시. close 는 transition 외부 effect 에서 수행한다.
+  // 같은 transition 안에서 onClose() 를 부르면 Chakra Dialog 의 inert/aria-hidden 정리가
+  // RSC 커밋과 경합해 메인 영역이 클릭 불가 상태로 남는 버그가 발생한다 (#43).
+  const submittingRef = useRef(false);
 
   // 모드 변경 시 폼 초기화 (모달 열릴 때).
   useEffect(() => {
@@ -87,6 +91,15 @@ export function TaskModal({ open, mode, onClose }: Props) {
     setSubmitError(null);
     setForm(mode.kind === 'edit' ? fromTask(mode.task) : EMPTY);
   }, [open, mode]);
+
+  // 트랜지션 종료 후 (성공) 모달 close. transition 외부에서 호출되어 RSC 커밋과 경합하지 않는다.
+  useEffect(() => {
+    if (pending) return;
+    if (!submittingRef.current) return;
+    submittingRef.current = false;
+    if (submitError) return;
+    onClose();
+  }, [pending, submitError, onClose]);
 
   if (!mode) return null;
 
@@ -102,6 +115,8 @@ export function TaskModal({ open, mode, onClose }: Props) {
     setErrors(errs);
     if (Object.keys(errs).length > 0) return;
 
+    setSubmitError(null);
+    submittingRef.current = true;
     startTransition(async () => {
       try {
         if (mode.kind === 'create') {
@@ -125,7 +140,6 @@ export function TaskModal({ open, mode, onClose }: Props) {
           };
           await updateTask(mode.task.id, patch);
         }
-        onClose();
       } catch (e) {
         setSubmitError(e instanceof Error ? e.message : '저장 중 오류가 발생했습니다');
       }

--- a/components/task-modal.tsx
+++ b/components/task-modal.tsx
@@ -15,6 +15,7 @@ import {
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { createTask, updateTask, type UpdateTaskPatch } from '@/app/actions/tasks';
 import type { Task } from '@/lib/tasks/queries';
+import { useGlobalProgress } from './progress-provider';
 
 export type TaskModalMode =
   | { kind: 'create'; parentId?: string | null; parentTitle?: string | null }
@@ -79,6 +80,7 @@ export function TaskModal({ open, mode, onClose }: Props) {
   const [errors, setErrors] = useState<Errors>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const progress = useGlobalProgress();
   // submit() 가 트랜지션을 시작했음을 표시. close 는 transition 외부 effect 에서 수행한다.
   // 같은 transition 안에서 onClose() 를 부르면 Chakra Dialog 의 inert/aria-hidden 정리가
   // RSC 커밋과 경합해 메인 영역이 클릭 불가 상태로 남는 버그가 발생한다 (#43).
@@ -97,9 +99,10 @@ export function TaskModal({ open, mode, onClose }: Props) {
     if (pending) return;
     if (!submittingRef.current) return;
     submittingRef.current = false;
+    progress.end();
     if (submitError) return;
     onClose();
-  }, [pending, submitError, onClose]);
+  }, [pending, submitError, onClose, progress]);
 
   if (!mode) return null;
 
@@ -117,6 +120,7 @@ export function TaskModal({ open, mode, onClose }: Props) {
 
     setSubmitError(null);
     submittingRef.current = true;
+    progress.begin();
     startTransition(async () => {
       try {
         if (mode.kind === 'create') {


### PR DESCRIPTION
## Summary

두 가지 UI 문제를 한 PR 에서 해결. 모두 영역:UI 단일 레이어 변경(합계 9파일, ≤150라인)이라 묶어서 진행 (CLAUDE.md §4 예외 조항).

### #43 — Dialog close 경합으로 인한 클릭 freeze 해결
- 작업 추가/수정 후 화면 전체가 클릭 안 되는 현상 수정
- 원인: `startTransition` 콜백 안에서 `await createTask()` 후 `onClose()` 를 호출하면 `revalidatePath` 의 RSC 커밋과 같은 transition 배치에 묶여 Chakra Dialog (Ark UI) 의 `inert`/`aria-hidden` cleanup 이 어긋남
- 해결: `submittingRef` 로 transition 시작만 표시하고 `onClose()` 는 `pending` 이 false 가 된 뒤 별도 `useEffect` 에서 호출. `task-actions-provider.tsx` 의 mode/state 클리어를 close 애니메이션 종료 후 (300ms) 로 지연

### #44 — 글로벌 프로그레스바 + 라우트 로딩
- 화면 상단에 인디터미네이트 Progress (height 2px, zIndex 9999)
- counter 패턴 `ProgressProvider` — 중첩 호출 안전
- `app/loading.tsx` — App Router 페이지 fallback
- task-modal / confirm-dialog 에 `begin()/end()` 연결

## Test plan
- [ ] 작업 생성 → 모달 닫힘 후 즉시 사이드바/행 클릭 가능 (J4 5회 연속)
- [ ] 작업 수정/삭제 후 동일 검증
- [ ] DevTools 에서 모달 close 후 `<body>`/메인 컨테이너에 `inert`/`aria-hidden`/`pointer-events:none` 잔존 없음
- [ ] 작업 생성 시 화면 상단 프로그레스바 잠깐 노출 → 사라짐
- [ ] Slow 3G throttling 에서 더 분명히 노출
- [ ] 페이지 새로고침 시 `loading.tsx` fallback 노출
- [ ] `npm run lint` / `npx tsc --noEmit` / `npm run build` 통과

Closes #43
Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)