### PR TITLE
refactor: #46 코드를 SPEC에 정렬

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# PR과 main push마다 lint · typecheck · build를 실행해 회귀를 막는다.
+# 테스트 러너(vitest 등)는 별도 이슈에서 도입.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    name: lint · typecheck · build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        env:
+          # 빌드 단계는 실제 DB/Supabase에 접속하지 않지만,
+          # process.env.* 가 undefined면 코드 경로가 깨질 수 있어 더미 값 주입.
+          NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321"
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: "ci-dummy-anon-key"
+          DATABASE_URL: "postgres://ci:ci@localhost:5432/ci"
+        run: npm run build

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, type MouseEvent } from 'react';
-import { Box, Flex, Text } from '@chakra-ui/react';
+import { Box, Flex, IconButton, Text } from '@chakra-ui/react';
 import type { TaskNode } from '@/lib/tasks/queries';
 import { isOverdue } from '@/lib/tasks/overdue';
 import { GanttBar } from './gantt-bar';
@@ -16,15 +16,34 @@ type Props = {
 type FlatRow = {
   node: TaskNode;
   depth: number;
+  hasChildren: boolean;
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const WEEK_MS = 7 * DAY_MS;
 
-function flatten(nodes: TaskNode[], depth = 0, acc: FlatRow[] = []): FlatRow[] {
+function flatten(
+  nodes: TaskNode[],
+  expanded: Set<string>,
+  depth = 0,
+  acc: FlatRow[] = [],
+): FlatRow[] {
   for (const node of nodes) {
-    acc.push({ node, depth });
-    if (node.children.length > 0) flatten(node.children, depth + 1, acc);
+    const hasChildren = node.children.length > 0;
+    acc.push({ node, depth, hasChildren });
+    if (hasChildren && expanded.has(node.id)) {
+      flatten(node.children, expanded, depth + 1, acc);
+    }
+  }
+  return acc;
+}
+
+function collectIdsWithChildren(nodes: TaskNode[], acc: Set<string> = new Set()): Set<string> {
+  for (const node of nodes) {
+    if (node.children.length > 0) {
+      acc.add(node.id);
+      collectIdsWithChildren(node.children, acc);
+    }
   }
   return acc;
 }
@@ -85,7 +104,26 @@ function buildWeekColumns(start: Date, end: Date): Date[] {
 }
 
 export function GanttView({ tasks }: Props) {
-  const rows = flatten(tasks);
+  const [expanded, setExpanded] = useState<Set<string>>(() => collectIdsWithChildren(tasks));
+
+  useEffect(() => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      for (const id of collectIdsWithChildren(tasks)) next.add(id);
+      return next;
+    });
+  }, [tasks]);
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const rows = flatten(tasks, expanded);
   const today = startOfDay(new Date());
   const { start: timelineStart, end: timelineEnd } = computeTimeline(rows, today);
   const weekCols = buildWeekColumns(timelineStart, timelineEnd);
@@ -158,8 +196,9 @@ export function GanttView({ tasks }: Props) {
             <Box flex="1">작업</Box>
             <Box width="3rem" textAlign="right">진행률</Box>
           </Flex>
-          {rows.map(({ node, depth }) => {
+          {rows.map(({ node, depth, hasChildren }) => {
             const overdue = isOverdue(node.dueDate, node.status);
+            const isExpanded = expanded.has(node.id);
             return (
               <Flex
                 key={node.id}
@@ -167,6 +206,7 @@ export function GanttView({ tasks }: Props) {
                 height={ROW_HEIGHT}
                 align="center"
                 px={3}
+                gap={4}
                 borderBottomWidth="1px"
                 borderColor="gray.100"
                 cursor={node.startDate ? 'pointer' : 'default'}
@@ -184,7 +224,24 @@ export function GanttView({ tasks }: Props) {
                     aria-label="지남"
                   />
                 )}
-                <Box flex="1" pl={`${depth * 1.25}rem`} minW={0}>
+                {depth > 0 && <Box flexShrink={0} width={`${depth * 1.25}rem`} />}
+                <Box flexShrink={0} display="flex" alignItems="center" justifyContent="center" width="1.5rem">
+                  {hasChildren ? (
+                    <IconButton
+                      aria-label={isExpanded ? '접기' : '펼치기'}
+                      aria-expanded={isExpanded}
+                      size="2xs"
+                      variant="ghost"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggle(node.id);
+                      }}
+                    >
+                      <Text fontSize="xs">{isExpanded ? '▼' : '▶'}</Text>
+                    </IconButton>
+                  ) : null}
+                </Box>
+                <Box flex="1" minW={0}>
                   <Text truncate fontSize="sm">{node.title}</Text>
                 </Box>
                 <Box width="3rem" textAlign="right">

--- a/components/status-badge.tsx
+++ b/components/status-badge.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Badge, Menu, Portal } from '@chakra-ui/react';
-import { useTransition } from 'react';
+import { Badge } from '@chakra-ui/react';
+import { useTransition, type KeyboardEvent, type MouseEvent } from 'react';
 import { updateTask } from '@/app/actions/tasks';
 
 type StatusKey = 'todo' | 'doing' | 'done';
@@ -28,46 +28,41 @@ type Props = {
 export function StatusBadge({ taskId, status }: Props) {
   const [pending, startTransition] = useTransition();
   const current: StatusKey = (LABEL as Record<string, string>)[status] ? (status as StatusKey) : 'todo';
+  const next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
 
-  const choose = (next: StatusKey) => {
-    if (next === current) return;
+  const advance = () => {
+    if (pending) return;
     startTransition(() => {
       void updateTask(taskId, { status: next });
     });
   };
 
+  const onClick = (e: MouseEvent) => {
+    // 행 클릭(편집 모달)으로 버블링되지 않도록 차단.
+    e.stopPropagation();
+    advance();
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      advance();
+    }
+  };
+
   return (
-    <Menu.Root
-      positioning={{ placement: 'bottom-start' }}
-      onSelect={(d) => choose(d.value as StatusKey)}
+    <Badge
+      role="button"
+      tabIndex={0}
+      colorPalette={PALETTE[current]}
+      cursor="pointer"
+      opacity={pending ? 0.6 : 1}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      aria-label={`상태 변경: 다음은 ${LABEL[next]}`}
     >
-      <Menu.Trigger
-        asChild
-        onClick={(e) => {
-          // 행 클릭(편집 모달 오픈)으로 버블링되지 않도록 차단.
-          e.stopPropagation();
-        }}
-      >
-        <Badge
-          colorPalette={PALETTE[current]}
-          cursor="pointer"
-          opacity={pending ? 0.6 : 1}
-          aria-label={`상태 변경: ${LABEL[current]}`}
-        >
-          {LABEL[current]}
-        </Badge>
-      </Menu.Trigger>
-      <Portal>
-        <Menu.Positioner>
-          <Menu.Content onClick={(e) => e.stopPropagation()}>
-            {ORDER.map((s) => (
-              <Menu.Item key={s} value={s}>
-                {LABEL[s]}
-              </Menu.Item>
-            ))}
-          </Menu.Content>
-        </Menu.Positioner>
-      </Portal>
-    </Menu.Root>
+      {LABEL[current]}
+    </Badge>
   );
 }

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Flex, IconButton, Menu, Portal, Progress, Text } from '@chakra-ui/react';
+import { Badge, Box, Flex, IconButton, Menu, Portal, Progress, Text } from '@chakra-ui/react';
 import type { TaskNode } from '@/lib/tasks/queries';
 import { isOverdue } from '@/lib/tasks/overdue';
 import { StatusBadge } from './status-badge';
@@ -45,26 +45,6 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
       cursor="pointer"
       onClick={() => openEdit(task)}
     >
-      {overdue && (
-        <>
-          <Box
-            position="absolute"
-            left={0}
-            top={0}
-            bottom={0}
-            width="3px"
-            bg="red.500"
-            zIndex={1}
-            aria-label="지남"
-          />
-          <Box
-            position="absolute"
-            inset={0}
-            pointerEvents="none"
-            bgImage="repeating-linear-gradient(45deg, transparent 0, transparent 6px, rgba(239,68,68,0.1) 6px, rgba(239,68,68,0.1) 10px)"
-          />
-        </>
-      )}
       <Box width="1.75rem" display="flex" justifyContent="center" flexShrink={0}>
         {hasChildren ? (
           <IconButton
@@ -77,7 +57,7 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
               onToggle();
             }}
           >
-            {expanded ? '▼' : '▶'}
+            <Text fontSize="xs">{expanded ? '▼' : '▶'}</Text>
           </IconButton>
         ) : null}
       </Box>
@@ -109,14 +89,19 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
         </Progress.Root>
       </Flex>
 
-      <Box width="9rem" flexShrink={0}>
+      <Flex width="9rem" flexShrink={0} align="center" gap={1}>
         <Text
           fontSize="sm"
           color={overdue ? 'red.500' : task.startDate || task.dueDate ? undefined : 'gray.500'}
         >
           {formatDateRange(task.startDate, task.dueDate)}
         </Text>
-      </Box>
+        {overdue && (
+          <Badge colorPalette="red" size="sm" aria-label="지남">
+            지남
+          </Badge>
+        )}
+      </Flex>
 
       <Box flexShrink={0}>
         <Menu.Root

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"


### PR DESCRIPTION
## 요약

SPEC.md를 진실의 원천으로 두고, 코드가 SPEC과 어긋나 있던 3가지를 정합. SPEC.md / USER_JOURNEY.md 본문은 변경하지 않음.

- **SPEC C-2** — 상태 배지를 드롭다운 메뉴에서 단일 클릭 순환(할 일 → 진행 중 → 완료 → 할 일)으로 복원. Enter/Space 키 접근성 포함.
- **SPEC A-4 / H-2 / H-4** — overdue 행의 좌측 액센트 바·빗금 오버레이를 제거하고 SPEC 그대로 `[지남]` 텍스트 배지를 기간 컬럼 옆에 표시.
- **SPEC G-4 목업** — 간트 좌측 트리에 ▼/▶ 펼침·접힘 토글 추가. 접힌 노드의 하위 작업은 좌측·우측 트랙 모두 숨김.

부수 — 목록 뷰 ▼/▶ 글리프가 안 보이던 정황을 해소하기 위해 IconButton 안에서 `<Text>`로 한 번 감쌌음.

## 추가 — 인프라 커밋 1건 (`chore:`)

이 PR 에는 SPEC 정합과 별개로 **CI 워크플로우 1개**가 함께 들어 있습니다 (PR이 열려 있는 상태에서 GitHub Actions 가 아예 돌지 않는다는 걸 확인하고 즉시 추가).

- `.github/workflows/ci.yml` — `pull_request` + `push(main)` 트리거. `npm ci → lint → typecheck → build` 4단계.
- `package.json` — `"typecheck": "tsc --noEmit"` 스크립트 추가 (새 의존성 0개).
- 테스트 러너(vitest 등) 도입은 **별도 이슈**로 분리.

> 본래 §4 원자성에 따라 별도 PR이 맞으나, 사용자 승인 하에 한 PR로 묶음 (파일 2개·45줄).

## 변경 파일

- `components/status-badge.tsx`
- `components/task-row.tsx`
- `components/gantt-view.tsx`
- `.github/workflows/ci.yml` *(신규)*
- `package.json` *(scripts 한 줄 추가)*

## 검증

- [x] `npm run lint` — 통과
- [x] `npm run typecheck` — 통과
- [x] `npm run build` — 통과 (더미 env 주입 시 PR/CI 환경에서도 통과 확인)
- [x] 브라우저: 배지 클릭 → 다음 상태로 1단계 회전, 새로고침 유지
- [x] 브라우저: overdue 행 `[지남]` 배지 + 날짜 빨강. 완료 전환 시 즉시 사라짐
- [x] 브라우저: 간트 좌측 트리 ▼ 클릭 → ▶ + 자식 막대 숨김, 다시 클릭 → 복귀
- [x] 회귀: J5(진행률 100→완료), J17(시작일>목표 기한 검증)
- [x] GitHub Actions 탭: 본 PR 에서 `CI / lint · typecheck · build` 잡 초록 체크

Closes #46