### PR TITLE
chore: .mcp.json wbs-prod 항목 추가

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -15,6 +15,10 @@
     "wbs-local": {
       "type": "http",
       "url": "http://localhost:3000/api/mcp"
+    },
+    "wbs-prod": {
+      "type": "http",
+      "url": "https://claude-vercel-wbs-sage.vercel.app/api/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

- `.mcp.json` 에 `wbs-prod` HTTP MCP 엔드포인트 항목 추가 (`https://claude-vercel-wbs-sage.vercel.app/api/mcp`)
- #48 후속 — 이미 머지된 `wbs-local` 옆에 한 줄 추가

## 동기

PR #49 머지 후 Vercel production 배포본 (`/api/mcp`)이 활성화됐고, Inspector CLI 4-call 시퀀스가 production URL 에서 통과하는 것을 확인했음 (.omc/inspector-evidence/prod-*.json).
이제 `.mcp.json` 에 `wbs-prod` 항목을 등록하면 Claude Code 가 별도 dev 서버 기동 없이도 production MCP 서버를 직접 호출 가능 (`mcp__wbs-prod__list_tasks` 등).

## Test plan

- [x] `.mcp.json` 이 유효한 JSON 임 (`jq . .mcp.json` 통과)
- [ ] (사람 검증) 새 Claude Code 세션 시작 후 `mcp__wbs-prod__list_tasks` 호출 시 prod DB 행 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)